### PR TITLE
Snippets

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -35,14 +35,16 @@
 
 using namespace std;
 
-struct Result
+class Result
 {
-  string url;
-  string title;
-  int score;
-  string snippet;
-  int wordCount;
-  int size;
+  public:
+    virtual ~Result() {};
+    virtual std::string get_url() = 0;
+    virtual std::string get_title() = 0;
+    virtual int get_score() = 0;
+    virtual std::string get_snippet() = 0;
+    virtual int get_wordCount() = 0;
+    virtual int get_size() = 0;
 };
 
 namespace kiwix {
@@ -55,7 +57,8 @@ namespace kiwix {
 
     void search(std::string &search, unsigned int resultStart,
 		unsigned int resultEnd, const bool verbose=false);
-    bool getNextResult(string &url, string &title, unsigned int &score);
+    virtual Result* getNextResult() = 0;
+    virtual void restart_search() = 0;
     unsigned int getEstimatedResultCount();
     bool setProtocolPrefix(const std::string prefix);
     bool setSearchProtocolPrefix(const std::string prefix);
@@ -72,8 +75,6 @@ namespace kiwix {
     virtual void searchInIndex(string &search, const unsigned int resultStart,
 			       const unsigned int resultEnd, const bool verbose=false) = 0;
 
-    std::vector<Result> results;
-    std::vector<Result>::iterator resultOffset;
     std::string searchPattern;
     std::string protocolPrefix;
     std::string searchProtocolPrefix;

--- a/include/xapianSearcher.h
+++ b/include/xapianSearcher.h
@@ -22,6 +22,8 @@
 
 #include <xapian.h>
 #include "searcher.h"
+#include "reader.h"
+
 #include <map>
 #include <string>
 
@@ -58,7 +60,7 @@ namespace kiwix {
   class XapianSearcher : public Searcher {
     friend class XapianResult;
   public:
-    XapianSearcher(const string &xapianDirectoryPath);
+    XapianSearcher(const string &xapianDirectoryPath, Reader* reader);
     virtual ~XapianSearcher() {};
     void searchInIndex(string &search, const unsigned int resultStart, const unsigned int resultEnd, 
 		       const bool verbose=false);
@@ -69,6 +71,7 @@ namespace kiwix {
     void closeIndex();
     void openIndex(const string &xapianDirectoryPath);
 
+    Reader* reader;
     Xapian::Database readableDatabase;
     Xapian::Stem stemmer;
     Xapian::MSet results;

--- a/include/xapianSearcher.h
+++ b/include/xapianSearcher.h
@@ -27,6 +27,23 @@ using namespace std;
 
 namespace kiwix {
 
+  class XapianResult : public Result {
+    public:
+      XapianResult(Xapian::MSetIterator& iterator);
+      virtual ~XapianResult() {};
+
+      virtual std::string get_url();
+      virtual std::string get_title();
+      virtual int get_score();
+      virtual std::string get_snippet();
+      virtual int get_wordCount();
+      virtual int get_size();
+
+    private:
+      Xapian::MSetIterator iterator;
+      Xapian::Document document;
+  };
+
   class NoXapianIndexInZim: public exception {
     virtual const char* what() const throw() {
       return "There is no fulltext index in the zim file";
@@ -40,6 +57,8 @@ namespace kiwix {
     virtual ~XapianSearcher() {};
     void searchInIndex(string &search, const unsigned int resultStart, const unsigned int resultEnd, 
 		       const bool verbose=false);
+    virtual Result* getNextResult();
+    void restart_search();
 
   protected:
     void closeIndex();
@@ -47,6 +66,8 @@ namespace kiwix {
 
     Xapian::Database readableDatabase;
     Xapian::Stem stemmer;
+    Xapian::MSet results;
+    Xapian::MSetIterator current_result;
   };
 
 }

--- a/include/xapianSearcher.h
+++ b/include/xapianSearcher.h
@@ -22,14 +22,18 @@
 
 #include <xapian.h>
 #include "searcher.h"
+#include <map>
+#include <string>
 
 using namespace std;
 
 namespace kiwix {
 
+  class XapianSearcher;
+
   class XapianResult : public Result {
     public:
-      XapianResult(Xapian::MSetIterator& iterator);
+      XapianResult(XapianSearcher* searcher, Xapian::MSetIterator& iterator);
       virtual ~XapianResult() {};
 
       virtual std::string get_url();
@@ -40,6 +44,7 @@ namespace kiwix {
       virtual int get_size();
 
     private:
+      XapianSearcher* searcher;
       Xapian::MSetIterator iterator;
       Xapian::Document document;
   };
@@ -51,7 +56,7 @@ namespace kiwix {
   };
 
   class XapianSearcher : public Searcher {
-    
+    friend class XapianResult;
   public:
     XapianSearcher(const string &xapianDirectoryPath);
     virtual ~XapianSearcher() {};
@@ -68,6 +73,7 @@ namespace kiwix {
     Xapian::Stem stemmer;
     Xapian::MSet results;
     Xapian::MSetIterator current_result;
+    std::map<std::string, int> valuesmap;
   };
 
 }

--- a/src/android/kiwix.cpp
+++ b/src/android/kiwix.cpp
@@ -445,7 +445,7 @@ JNIEXPORT jboolean JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_loadFulltextIndex(JN
   searcher = NULL;
   try {
     if (searcher != NULL) delete searcher;
-    searcher = new kiwix::XapianSearcher(cPath);
+    searcher = new kiwix::XapianSearcher(cPath, NULL);
   } catch (...) {
     searcher = NULL;
     retVal = JNI_FALSE;

--- a/src/android/kiwix.cpp
+++ b/src/android/kiwix.cpp
@@ -460,19 +460,18 @@ JNIEXPORT jstring JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_indexedQuery
   (JNIEnv *env, jclass obj, jstring query, jint count) {
   std::string cQuery = jni2c(query, env);
   unsigned int cCount = jni2c(count);
-  std::string url;
-  std::string title;
+  kiwix::Result *p_result;
   std::string result;
-  unsigned int score;
       
   pthread_mutex_lock(&searcherLock);
   try {
     if (searcher != NULL) {
       searcher->search(cQuery, 0, count);
-      while (searcher->getNextResult(url, title, score) &&
-	     !title.empty() &&
-	     !url.empty()) {
-	result += title + "\n";
+      while ( (p_result = searcher->getNextResult()) &&
+	     !(p_result->get_title().empty()) &&
+	     !(p_result->get_url().empty())) {
+	result += p_result->get_title() + "\n";
+	delete p_result;
       }
     }
   } catch (...) {


### PR DESCRIPTION
Better handling of snippets in kiwix-lib. Snippets are now generated from the article content if not
present in the database.

This make also the database smaller. From my test, the database is 15% smaller than with the snippet.