### PR TITLE
Remove C++11 syntax introduced by commit 9be2abe.

### DIFF
--- a/src/xapianSearcher.cpp
+++ b/src/xapianSearcher.cpp
@@ -33,9 +33,11 @@ namespace kiwix {
 std::map<std::string, int> read_valuesmap(const std::string &s) {
     std::map<std::string, int> result;
     std::vector<std::string> elems = split(s, ";");
-    for( auto elem: elems)
+    for(std::vector<std::string>::iterator elem = elems.begin();
+        elem != elems.end();
+        elem++)
     {
-        std::vector<std::string> tmp_elems = split(elem, ":");
+        std::vector<std::string> tmp_elems = split(*elem, ":");
         result.insert( std::pair<std::string, int>(tmp_elems[0], atoi(tmp_elems[1].c_str())) );
     }
     return result;


### PR DESCRIPTION
We really need to advance on kiwix-build stuff to allow us to run travis on all commit of subprojects :)

The `for( auto elem: elems)` syntax is a C++11 syntax.
We are not using C++11 (even if it would be good idea).
This works on recent compiler (on Fedora 25) but fails on older one
(on Travis).