### PR TITLE
The `Result` class is not in the `kiwix` namespace. (fix android build)

### DIFF
--- a/src/android/kiwix.cpp
+++ b/src/android/kiwix.cpp
@@ -460,7 +460,7 @@ JNIEXPORT jstring JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_indexedQuery
   (JNIEnv *env, jclass obj, jstring query, jint count) {
   std::string cQuery = jni2c(query, env);
   unsigned int cCount = jni2c(count);
-  kiwix::Result *p_result;
+  Result *p_result;
   std::string result;
       
   pthread_mutex_lock(&searcherLock);


### PR DESCRIPTION
The commit 83d2725 adapt the jni wrapper to the new search API but try to
use the `Result` class from the `kiwix` namespace but `Result` is not in
the namespace.

A correct fix would be to move `Result` in `kiwix` but it also change the
API for other tools (kiwix-tools). As we will move the search
functionality in `zimlib` it is better to just do this silly fix and
update the API latter when moving the search functionality.