### PR TITLE
Do not use remove readStopWords method.

### DIFF
--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -85,7 +85,7 @@ namespace kiwix {
     unsigned int newProgress;
 
     /* StopWords */
-    self->readStopWords(reader.getLanguage());
+//    self->readStopWords(reader.getLanguage());
 
     /* Goes trough all articles */
     zim::File *zimHandler = reader.getZimFileHandler();


### PR DESCRIPTION
Commit b8d950c removes this symbol.
The indexer is not used anymore and will be soon removed.
So for now, just remove the call to readStopWords until we totally
remove the indexer code.