### PR TITLE
Move unicode headers in cpp.

### DIFF
--- a/include/common/stringTools.h
+++ b/include/common/stringTools.h
@@ -20,13 +20,7 @@
 #ifndef KIWIX_STRINGTOOLS_H
 #define KIWIX_STRINGTOOLS_H
 
-#include <unicode/translit.h>
-#include <unicode/normlzr.h>
 #include <unicode/unistr.h>
-#include <unicode/rep.h>
-#include <unicode/uniset.h>
-#include <unicode/ustring.h>
-#include <unicode/ucnv.h>
 
 #include <iostream>
 #include <vector>

--- a/src/common/stringTools.cpp
+++ b/src/common/stringTools.cpp
@@ -19,6 +19,13 @@
 
 #include <common/stringTools.h>
 
+#include <unicode/translit.h>
+#include <unicode/normlzr.h>
+#include <unicode/ustring.h>
+#include <unicode/rep.h>
+#include <unicode/uniset.h>
+#include <unicode/ucnv.h>
+
 /* tell ICU where to find its dat file (tables) */
 void kiwix::loadICUExternalTables() {
 #ifdef __APPLE__


### PR DESCRIPTION
Unicode headers ends by defining the DONE symbol in a enum.
It can clash with other includes.
(For instance the httpd.h from apache who use `#define DONE -2`).

Both project should not declare such common symbols publicly but we have
to do with them anyway.