### PR TITLE
Update kiwix-lib to new kiwix-android way of building.

### DIFF
--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+
+  package="kiwix.org.kiwixlib"
+>
+
+  <application android:allowBackup="true"
+    android:label="@string/app_name"
+    android:supportsRtl="true"
+  >
+
+  </application>
+
+</manifest>

--- a/src/android/meson.build
+++ b/src/android/meson.build
@@ -11,3 +11,7 @@ kiwix_jni = custom_target('jni',
 )
 
 kiwix_sources += ['android/kiwix.cpp', kiwix_jni]
+
+install_subdir('org', install_dir: 'kiwix-lib/java')
+install_subdir('res', install_dir: 'kiwix-lib')
+install_data('AndroidManifest.xml', install_dir: 'kiwix-lib')

--- a/src/android/res/values/strings.xml
+++ b/src/android/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="app_name">Kiwix Lib</string>
+</resources>

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,11 @@ kiwix_sources += lib_resources
 
 if get_option('android')
   subdir('android')
+  install_dir = 'kiwix-lib/jniLibs/' + host_machine.cpu_family()
+else
+  install_dir = get_option('libdir')
 endif
+
 
 if has_ctpp2_dep
   kiwix_sources += ['ctpp2/CTPP2VMStringLoader.cpp']
@@ -30,4 +34,5 @@ kiwixlib = library('kiwix',
                    include_directories : inc,
                    dependencies : all_deps,
                    version: '1.0.0',
-                   install : true)
+                   install: true,
+                   install_dir: install_dir)


### PR DESCRIPTION
`kiwix-android` is using `kiwix-lib` as an external java application now.
So we need `kiwix-lib` build system to also install application files
(manifest, resources, ..).