### PR TITLE
Meson 'ctpp2_include_path' has to be declared

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ libicu_dep = dependency('icu-i18n')
 libzim_dep = dependency('libzim')
 pugixml_dep = dependency('pugixml')
 
-
+ctpp2_include_path = ''
 has_ctpp2_dep = false
 ctpp2_prefix_install = get_option('ctpp2-install-prefix')
 ctpp2_link_args = []


### PR DESCRIPTION
Otherwise you might get this kind of error:
```
$ rm -rf build/ && meson . build
The Meson build system
Version: 0.40.1
Source dir: /home/kiwix/kiwix-lib
Build dir: /home/kiwix/kiwix-lib/build
Build type: native build
Project name: kiwixlib
Native cpp compiler: c++ (gcc 5.4.0)
Build machine cpu family: x86_64
Build machine cpu: x86_64
Dependency threads found: YES
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Native dependency icu-i18n found: YES 55.1
Native dependency libzim found: YES 1.4
Native dependency pugixml found: YES 1.8
Has header "ctpp2/CTPP2Logger.hpp": YES
Library ctpp2 found: YES
Program compile_resources.py found: YES (/home/kiwix/kiwix-lib/scripts/compile_resources.py)
Configuring kiwix_config.h using configuration

Meson encountered an error in file meson.build, line 86, column 5:
Unknown variable "ctpp2_include_path".

```