### PR TITLE
Check that 'M/Counter' exists before trying to read it.

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -103,15 +103,17 @@ namespace kiwix {
 
     zim::Article article = this->zimFileHandler->getArticle('M',"Counter");
 
-    stringstream ssContent(article.getData());
+    if ( article.good() ) {
+      stringstream ssContent(article.getData());
 
-    while(getline(ssContent, item,  ';')) {
-      stringstream ssItem(item);
-      getline(ssItem, mimeType, '=');
-      getline(ssItem, counterString, '=');
-      if (!counterString.empty() && !mimeType.empty()) {
-	sscanf(counterString.c_str(), "%u", &counter);
-	counters.insert(pair<string, int>(mimeType, counter));
+      while(getline(ssContent, item,  ';')) {
+        stringstream ssItem(item);
+        getline(ssItem, mimeType, '=');
+        getline(ssItem, counterString, '=');
+        if (!counterString.empty() && !mimeType.empty()) {
+	  sscanf(counterString.c_str(), "%u", &counter);
+	  counters.insert(pair<string, int>(mimeType, counter));
+        }
       }
     }
 


### PR DESCRIPTION
Some old zim files may not have a 'Counter` metadata article.
We have to handle this correctly.

Fix https://github.com/kiwix/kiwix-tools/issues/33