### PR TITLE
Re-add xapian searcher in kiwix-lib.

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -5,6 +5,10 @@ headers = [
   'searcher.h'
 ]
 
+if xapian_dep.found()
+  headers += ['xapianSearcher.h']
+endif
+
 install_headers(headers, subdir:'kiwix')
 
 install_headers(

--- a/include/searcher.h
+++ b/include/searcher.h
@@ -53,7 +53,7 @@ namespace kiwix {
   class Searcher {
 
   public:
-    Searcher(Reader* reader);
+    Searcher(const string &xapianDirectoryPath, Reader* reader);
     ~Searcher();
 
     void search(std::string &search, unsigned int resultStart,

--- a/include/xapianSearcher.h
+++ b/include/xapianSearcher.h
@@ -57,7 +57,7 @@ namespace kiwix {
     }
   };
 
-  class XapianSearcher : public Searcher {
+  class XapianSearcher {
     friend class XapianResult;
   public:
     XapianSearcher(const string &xapianDirectoryPath, Reader* reader);
@@ -66,6 +66,8 @@ namespace kiwix {
 		       const bool verbose=false);
     virtual Result* getNextResult();
     void restart_search();
+
+    Xapian::MSet results;
 
   protected:
     void closeIndex();
@@ -79,7 +81,6 @@ namespace kiwix {
     Xapian::QueryParser queryParser;
     Xapian::Stem stemmer;
     Xapian::SimpleStopper stopper;
-    Xapian::MSet results;
     Xapian::MSetIterator current_result;
     std::map<std::string, int> valuesmap;
   };

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,9 @@ else
   endif
 endif
 
-all_deps = [thread_dep, libicu_dep, libzim_dep, pugixml_dep]
+xapian_dep = dependency('xapian-core', required:false)
+
+all_deps = [thread_dep, libicu_dep, libzim_dep, xapian_dep, pugixml_dep]
 if has_ctpp2_dep
   all_deps += [ctpp2_dep]
 endif
@@ -79,6 +81,9 @@ subdir('static')
 subdir('src')
 
 pkg_requires = ['libzim', 'icu-i18n', 'pugixml']
+if xapian_dep.found()
+    pkg_requires += ['xapian-core']
+endif
 
 extra_libs = []
 extra_cflags = ''

--- a/src/android/kiwix.cpp
+++ b/src/android/kiwix.cpp
@@ -445,7 +445,7 @@ JNIEXPORT jboolean JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_loadFulltextIndex(JN
   searcher = NULL;
   try {
     if (searcher != NULL) delete searcher;
-    searcher = new kiwix::Searcher(reader);
+    searcher = new kiwix::Searcher(cPath, reader);
   } catch (...) {
     searcher = NULL;
     retVal = JNI_FALSE;

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,9 +8,15 @@ kiwix_sources = [
   'common/regexTools.cpp',
   'common/stringTools.cpp',
   'common/networkTools.cpp',
-  'common/otherTools.cpp'
+  'common/otherTools.cpp',
+  'xapian/htmlparse.cc',
+  'xapian/myhtmlparse.cc'
 ]
 kiwix_sources += lib_resources
+
+if xapian_dep.found()
+  kiwix_sources += ['xapianSearcher.cpp']
+endif
 
 if get_option('android')
   subdir('android')

--- a/src/xapianSearcher.cpp
+++ b/src/xapianSearcher.cpp
@@ -46,27 +46,14 @@ std::map<std::string, int> read_valuesmap(const std::string &s) {
 
   /* Constructor */
   XapianSearcher::XapianSearcher(const string &xapianDirectoryPath, Reader* reader)
-    : Searcher(),
-      reader(reader)
+    : reader(reader)
   {
     this->openIndex(xapianDirectoryPath);
   }
 
   /* Open Xapian readable database */
   void XapianSearcher::openIndex(const string &directoryPath) {
-    try
-    {
-      zim::File zimFile = zim::File(directoryPath);
-      zim::Article xapianArticle = zimFile.getArticle('Z', "/fulltextIndex/xapian");
-      if (!xapianArticle.good())
-	throw NoXapianIndexInZim();
-      zim::offset_type dbOffset = xapianArticle.getOffset();
-      int databasefd = open(directoryPath.c_str(), O_RDONLY);
-      lseek(databasefd, dbOffset, SEEK_SET);
-      this->readableDatabase = Xapian::Database(databasefd);
-    } catch (...) {
-      this->readableDatabase = Xapian::Database(directoryPath);
-    }
+    this->readableDatabase = Xapian::Database(directoryPath);
     this->valuesmap = read_valuesmap(this->readableDatabase.get_metadata("valuesmap"));
     this->language = this->readableDatabase.get_metadata("language");
     this->stopwords = this->readableDatabase.get_metadata("stopwords");
@@ -121,9 +108,6 @@ std::map<std::string, int> read_valuesmap(const std::string &s) {
     /* Get the results */
     this->results = enquire.get_mset(resultStart, resultEnd - resultStart);
     this->current_result = this->results.begin();
-
-    /* Update the global resultCount value*/
-    this->estimatedResultCount = this->results.get_matches_estimated();
   }
 
   /* Get next result */


### PR DESCRIPTION
libzim only know how to read embedded full text index in a zim file.
This is nice as we want to embedded the full text index in zim file and
not have separated full text index.

However, we still have some zim+separated index we have to read.
So we have to support the search in separated index for a while.