### PR TITLE
Use the cpu name instead of cpu_family as install dir name.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -20,7 +20,7 @@ endif
 
 if get_option('android')
   subdir('android')
-  install_dir = 'kiwix-lib/jniLibs/' + host_machine.cpu_family()
+  install_dir = 'kiwix-lib/jniLibs/' + meson.get_cross_property('android_abi')
 else
   install_dir = get_option('libdir')
 endif


### PR DESCRIPTION
Android will look in specific repository to find native libs.
We need to use the `cpu` name instead of `cpu_family`.

Should fix https://github.com/kiwix/kiwix-android/issues/151