### PR TITLE
Fix type error in build

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -128,7 +128,7 @@ namespace kiwix {
     if (counterMap.empty()) {
       counter = this->nsACount;
     } else {
-      std::map<std::string, unsigned int>::const_iterator it = counterMap.find("text/html");
+      auto it = counterMap.find("text/html");
       if (it != counterMap.end())
 	counter = it->second;
     }
@@ -144,9 +144,7 @@ namespace kiwix {
     if (counterMap.empty())
       counter = this->nsICount;
     else {
-      std::map<std::string, unsigned int>::const_iterator it;
-
-      it = counterMap.find("image/jpeg");
+      auto it = counterMap.find("image/jpeg");
       if (it != counterMap.end())
 	counter += it->second;
 


### PR DESCRIPTION
c++  '-Isrc/kiwix@sha' '-Isrc' '-Istatic' '-I../src' '-Iinclude' '-I../include' '-I/usr/local/include' '-I/usr/local/include/' '-I/usr/local/include/pugixml-1.8' '-L/usr/local/lib' '-Xclang' '-fcolor-diagnostics' '-pipe' '-D_FILE_OFFSET_BITS=64' '-Wall' '-Winvalid-pch' '-Wnon-virtual-dtor' '-std=c++11' '-O3' '-O2' '-fstack-protector' '-isystem' '/usr/local/include' '-fno-strict-aliasing' '-isystem' '/usr/local/include' '-isystem' '/usr/local/include' '-fPIC' '-pthread' '-MMD' '-MQ' 'src/kiwix@sha/reader.cpp.o' '-MF' 'src/kiwix@sha/reader.cpp.o.d' -o 'src/kiwix@sha/reader.cpp.o' -c ../src/reader.cpp
FAILED: src/kiwix@sha/reader.cpp.o
c++  '-Isrc/kiwix@sha' '-Isrc' '-Istatic' '-I../src' '-Iinclude' '-I../include' '-I/usr/local/include' '-I/usr/local/include/' '-I/usr/local/include/pugixml-1.8' '-L/usr/local/lib' '-Xclang' '-fcolor-diagnostics' '-pipe' '-D_FILE_OFFSET_BITS=64' '-Wall' '-Winvalid-pch' '-Wnon-virtual-dtor' '-std=c++11' '-O3' '-O2' '-fstack-protector' '-isystem' '/usr/local/include' '-fno-strict-aliasing' '-isystem' '/usr/local/include' '-isystem' '/usr/local/include' '-fPIC' '-pthread' '-MMD' '-MQ' 'src/kiwix@sha/reader.cpp.o' '-MF' 'src/kiwix@sha/reader.cpp.o.d' -o 'src/kiwix@sha/reader.cpp.o' -c ../src/reader.cpp
c++: warning: argument unused during compilation: '-L/usr/local/lib'
../src/reader.cpp:131:59: error: no viable conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::map<std::string, unsigned int>::const_iterator' (aka '__map_const_iterator<typename __base::const_iterator>')
      std::map<std::string, unsigned int>::const_iterator it = counterMap.find("text/html");
                                                          ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/map:713:29: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> > &' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
/usr/include/c++/v1/map:713:29: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> > &&' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
/usr/include/c++/v1/map:737:5: note: candidate constructor not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long>' for 1st argument
    __map_const_iterator(_TreeIterator __i) _NOEXCEPT : __i_(__i) {}
    ^
/usr/include/c++/v1/map:739:5: note: candidate constructor not viable: no known conversion from '__map_iterator<__tree_iterator<__value_type<const basic_string<[3 * ...]>, [...]>, __node_pointer, [...]>>' to '__map_iterator<__tree_iterator<__value_type<basic_string<[3 * ...]>, [...]>, __non_const_node_pointer, [...]>>' for 1st argument
    __map_const_iterator(
    ^
../src/reader.cpp:149:10: error: no viable overloaded '='
      it = counterMap.find("image/jpeg");
      ~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/map:713:29: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> >' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
/usr/include/c++/v1/map:713:29: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> >' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
../src/reader.cpp:150:14: error: invalid operands to binary expression ('std::map<std::string, unsigned int>::const_iterator' (aka '__map_const_iterator<typename __base::const_iterator>') and 'iterator' (aka '__map_iterator<typename __base::iterator>'))
      if (it != counterMap.end())
          ~~ ^  ~~~~~~~~~~~~~~~~
../src/reader.cpp:153:10: error: no viable overloaded '='
      it = counterMap.find("image/gif");
      ~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/map:713:29: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> >' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
/usr/include/c++/v1/map:713:29: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> >' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
../src/reader.cpp:154:14: error: invalid operands to binary expression ('std::map<std::string, unsigned int>::const_iterator' (aka '__map_const_iterator<typename __base::const_iterator>') and 'iterator' (aka '__map_iterator<typename __base::iterator>'))
      if (it != counterMap.end())
          ~~ ^  ~~~~~~~~~~~~~~~~
../src/reader.cpp:157:10: error: no viable overloaded '='
      it = counterMap.find("image/png");
      ~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/map:713:29: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> >' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
/usr/include/c++/v1/map:713:29: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_const_iterator<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char>, unsigned int>, void *> *, long> >' for 1st argument
class _LIBCPP_TYPE_VIS_ONLY __map_const_iterator
                            ^
../src/reader.cpp:158:14: error: invalid operands to binary expression ('std::map<std::string, unsigned int>::const_iterator' (aka '__map_const_iterator<typename __base::const_iterator>') and 'iterator' (aka '__map_iterator<typename __base::iterator>'))
      if (it != counterMap.end())
          ~~ ^  ~~~~~~~~~~~~~~~~
7 errors generated.
ninja: build stopped: subcommand failed.