### PR TITLE
Iterator must be of the same type than the map we are iterating.

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -128,7 +128,7 @@ namespace kiwix {
     if (counterMap.empty()) {
       counter = this->nsACount;
     } else {
-      std::map<std::string, unsigned int>::const_iterator it = counterMap.find("text/html");
+      std::map<const std::string, unsigned int>::const_iterator it = counterMap.find("text/html");
       if (it != counterMap.end())
 	counter = it->second;
     }
@@ -144,7 +144,7 @@ namespace kiwix {
     if (counterMap.empty())
       counter = this->nsICount;
     else {
-      std::map<std::string, unsigned int>::const_iterator it;
+      std::map<const std::string, unsigned int>::const_iterator it;
 
       it = counterMap.find("image/jpeg");
       if (it != counterMap.end())


### PR DESCRIPTION
Fix for [kiwix-lib not building successfully on macOS (natively)](https://github.com/kiwix/kiwix-build/issues/29). The modification in this branch has been tested successfully on macOS 10.12.4