### PR TITLE
getContent* methods also allow to get the title.

### DIFF
--- a/include/reader.h
+++ b/include/reader.h
@@ -66,24 +66,29 @@ class Reader
   bool getMimeTypeByUrl(const string& url, string& mimeType) const;
   bool getContentByUrl(const string& url,
                        string& content,
+                       string& title,
                        unsigned int& contentLength,
                        string& contentType) const;
   bool getContentByEncodedUrl(const string& url,
                               string& content,
+                              string& title,
                               unsigned int& contentLength,
                               string& contentType,
                               string& baseUrl) const;
   bool getContentByEncodedUrl(const string& url,
                               string& content,
+                              string& title,
                               unsigned int& contentLength,
                               string& contentType) const;
   bool getContentByDecodedUrl(const string& url,
                               string& content,
+                              string& title,
                               unsigned int& contentLength,
                               string& contentType,
                               string& baseUrl) const;
   bool getContentByDecodedUrl(const string& url,
                               string& content,
+                              string& title,
                               unsigned int& contentLength,
                               string& contentType) const;
   bool searchSuggestions(const string& prefix,

--- a/src/android/kiwix.cpp
+++ b/src/android/kiwix.cpp
@@ -323,9 +323,10 @@ Java_org_kiwix_kiwixlib_JNIKiwix_loadZIM(JNIEnv* env, jobject obj, jstring path)
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_getContent(
-    JNIEnv* env, jobject obj, jstring url, jobject mimeTypeObj, jobject sizeObj)
+    JNIEnv* env, jobject obj, jstring url, jobject titleObj, jobject mimeTypeObj, jobject sizeObj)
 {
   /* Default values */
+  setStringObjValue("", titleObj, env);
   setStringObjValue("", mimeTypeObj, env);
   setIntObjValue(0, sizeObj, env);
   jbyteArray data = env->NewByteArray(0);
@@ -334,16 +335,18 @@ JNIEXPORT jbyteArray JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_getContent(
   if (reader != NULL) {
     std::string cUrl = jni2c(url, env);
     std::string cData;
+    std::string cTitle;
     std::string cMimeType;
     unsigned int cSize = 0;
 
     pthread_mutex_lock(&readerLock);
     try {
-      if (reader->getContentByUrl(cUrl, cData, cSize, cMimeType)) {
+      if (reader->getContentByUrl(cUrl, cData, cTitle, cSize, cMimeType)) {
         data = env->NewByteArray(cSize);
         env->SetByteArrayRegion(
             data, 0, cSize, reinterpret_cast<const jbyte*>(cData.c_str()));
         setStringObjValue(cMimeType, mimeTypeObj, env);
+        setStringObjValue(cTitle, titleObj, env);
         setIntObjValue(cSize, sizeObj, env);
       }
     } catch (...) {

--- a/src/android/org/kiwix/kiwixlib/JNIKiwix.java
+++ b/src/android/org/kiwix/kiwixlib/JNIKiwix.java
@@ -38,7 +38,7 @@ public class JNIKiwix
 
   public native boolean loadFulltextIndex(String path);
 
-  public native byte[] getContent(String url, JNIKiwixString mimeType, JNIKiwixInt size);
+  public native byte[] getContent(String url, JNIKiwixString title, JNIKiwixString mimeType, JNIKiwixInt size);
 
   public native boolean searchSuggestions(String prefix, int count);
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -252,17 +252,18 @@ string Reader::getMainPageUrl() const
 bool Reader::getFavicon(string& content, string& mimeType) const
 {
   unsigned int contentLength = 0;
+  string title;
 
-  this->getContentByUrl("/-/favicon.png", content, contentLength, mimeType);
+  this->getContentByUrl("/-/favicon.png", content, title, contentLength, mimeType);
 
   if (content.empty()) {
-    this->getContentByUrl("/I/favicon.png", content, contentLength, mimeType);
+    this->getContentByUrl("/I/favicon.png", content, title, contentLength, mimeType);
 
     if (content.empty()) {
-      this->getContentByUrl("/I/favicon", content, contentLength, mimeType);
+      this->getContentByUrl("/I/favicon", content, title, contentLength, mimeType);
 
       if (content.empty()) {
-        this->getContentByUrl("/-/favicon", content, contentLength, mimeType);
+        this->getContentByUrl("/-/favicon", content, title, contentLength, mimeType);
       }
     }
   }
@@ -279,8 +280,9 @@ bool Reader::getMetatag(const string& name, string& value) const
 {
   unsigned int contentLength = 0;
   string contentType = "";
+  string title;
 
-  return this->getContentByUrl("/M/" + name, value, contentLength, contentType);
+  return this->getContentByUrl("/M/" + name, value, title, contentLength, contentType);
 }
 
 string Reader::getTitle() const
@@ -467,30 +469,34 @@ bool Reader::getMimeTypeByUrl(const string& url, string& mimeType) const
 /* Get a content from a zim file */
 bool Reader::getContentByUrl(const string& url,
                              string& content,
+                             string& title,
                              unsigned int& contentLength,
                              string& contentType) const
 {
-  return this->getContentByEncodedUrl(url, content, contentLength, contentType);
+  return this->getContentByEncodedUrl(url, content, title, contentLength, contentType);
 }
 
 bool Reader::getContentByEncodedUrl(const string& url,
                                     string& content,
+                                    string& title,
                                     unsigned int& contentLength,
                                     string& contentType,
                                     string& baseUrl) const
 {
   return this->getContentByDecodedUrl(
-      kiwix::urlDecode(url), content, contentLength, contentType, baseUrl);
+      kiwix::urlDecode(url), content, title, contentLength, contentType, baseUrl);
 }
 
 bool Reader::getContentByEncodedUrl(const string& url,
                                     string& content,
+                                    string& title,
                                     unsigned int& contentLength,
                                     string& contentType) const
 {
   std::string stubRedirectUrl;
   return this->getContentByEncodedUrl(kiwix::urlDecode(url),
                                       content,
+                                      title,
                                       contentLength,
                                       contentType,
                                       stubRedirectUrl);
@@ -498,12 +504,14 @@ bool Reader::getContentByEncodedUrl(const string& url,
 
 bool Reader::getContentByDecodedUrl(const string& url,
                                     string& content,
+                                    string& title,
                                     unsigned int& contentLength,
                                     string& contentType) const
 {
   std::string stubRedirectUrl;
   return this->getContentByDecodedUrl(kiwix::urlDecode(url),
                                       content,
+                                      title,
                                       contentLength,
                                       contentType,
                                       stubRedirectUrl);
@@ -511,6 +519,7 @@ bool Reader::getContentByDecodedUrl(const string& url,
 
 bool Reader::getContentByDecodedUrl(const string& url,
                                     string& content,
+                                    string& title,
                                     unsigned int& contentLength,
                                     string& contentType,
                                     string& baseUrl) const
@@ -547,6 +556,7 @@ bool Reader::getContentByDecodedUrl(const string& url,
 
     /* Get the data */
     content = string(article.getData().data(), article.getArticleSize());
+    title = article.getTitle();
   }
 
   /* Try to set a stub HTML header/footer if necesssary */

--- a/src/xapianSearcher.cpp
+++ b/src/xapianSearcher.cpp
@@ -194,10 +194,11 @@ std::string XapianResult::get_content()
     return "";
   }
   std::string content;
+  std::string title;
   unsigned int contentLength;
   std::string contentType;
   searcher->reader->getContentByUrl(
-      get_url(), content, contentLength, contentType);
+      get_url(), content, title, contentLength, contentType);
   return content;
 }
 


### PR DESCRIPTION
Add a `title` write argument to `getContent*` methods.
This argument is filled with the title of the content get.

Also update the JNI accordingly.

Related to kiwix/kiwix-android#214