### PR TITLE
Always set the humanReadableName with the readable in kiwix-search.

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -57,7 +57,9 @@ class Searcher
 {
  public:
   Searcher();
-  Searcher(const string& xapianDirectoryPath, Reader* reader);
+  Searcher(const string& xapianDirectoryPath,
+           Reader* reader,
+           const string& humanReadableName);
   ~Searcher();
 
   void add_reader(Reader* reader, const std::string& humanReaderName);
@@ -72,7 +74,6 @@ class Searcher
   bool setProtocolPrefix(const std::string prefix);
   bool setSearchProtocolPrefix(const std::string prefix);
   void reset();
-  void setContentHumanReadableId(const string& contentHumanReadableId);
 
 #ifdef ENABLE_CTPP2
   string getHtml();

--- a/src/android/kiwix.cpp
+++ b/src/android/kiwix.cpp
@@ -514,7 +514,7 @@ JNIEXPORT jboolean JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_loadFulltextIndex(
     }
     if (!reader || !reader->hasFulltextIndex()) {
       // Use old API (no embedded full text index).
-      searcher = new kiwix::Searcher(cPath, reader);
+      searcher = new kiwix::Searcher(cPath, reader, "");
     } else {
       // Use the new API. We don't care about the human readable name as
       // we don't use it (in android).

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -73,7 +73,9 @@ struct SearcherInternal {
 };
 
 /* Constructor */
-Searcher::Searcher(const string& xapianDirectoryPath, Reader* reader)
+Searcher::Searcher(const string& xapianDirectoryPath,
+                   Reader* reader,
+                   const string& humanReadableName)
     : internal(new SearcherInternal()),
       searchPattern(""),
       protocolPrefix("zim://"),
@@ -88,6 +90,8 @@ Searcher::Searcher(const string& xapianDirectoryPath, Reader* reader)
   if (!reader || !reader->hasFulltextIndex()) {
     internal->_xapianSearcher = new XapianSearcher(xapianDirectoryPath, reader);
   }
+  this->contentHumanReadableId = humanReadableName;
+  this->humanReaderNames.push_back(humanReadableName);
 }
 
 Searcher::Searcher()
@@ -250,11 +254,6 @@ bool Searcher::setSearchProtocolPrefix(const std::string prefix)
 {
   this->searchProtocolPrefix = prefix;
   return true;
-}
-
-void Searcher::setContentHumanReadableId(const string& contentHumanReadableId)
-{
-  this->contentHumanReadableId = contentHumanReadableId;
 }
 
 _Result::_Result(Searcher* searcher, zim::Search::iterator& iterator)


### PR DESCRIPTION
We always need a humanReadableName associated with a content to search in.
Do not separate the two values (human readable name and zim) in two
different functions.

This way, we avoid miss-use of the Searcher who could lead to segfault.