### PR TITLE
Claims that multi part zim has no embedded full text index.

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -589,7 +589,8 @@ bool Reader::urlExists(const string& url) const
 /* Does the ZIM file has a fulltext index */
 bool Reader::hasFulltextIndex() const
 {
-  return this->urlExists("/Z/fulltextIndex/xapian");
+  return ( this->urlExists("/Z/fulltextIndex/xapian")
+        && !zimFileHandler->is_multiPart() );
 }
 
 /* Search titles by prefix */


### PR DESCRIPTION
We cannot search into an embedded fulltext index if the zim is multipart.
Instead of crashing, let's pretend we have no fulltext index.

Fixes kiwix/kiwix-tools#65
No search will be proposed to the user.

Depends on openzim/libzim#43