### PR TITLE
[resource_compiler] Make the exception public.

### DIFF
--- a/scripts/kiwix-compile-resources
+++ b/scripts/kiwix-compile-resources
@@ -106,15 +106,7 @@ master_c_template = """//This file is automaically generated. Do not modify it.
 
 #include <stdlib.h>
 #include <fstream>
-#include <stdexcept>
 #include "{include_file}"
-
-class ResourceNotFound : public std::runtime_error {{
-  public:
-    ResourceNotFound(const std::string& what_arg):
-      std::runtime_error(what_arg)
-    {{ }};
-}};
 
 static std::string init_resource(const char* name, const unsigned char* content, int len)
 {{
@@ -153,9 +145,17 @@ master_h_template = """//This file is automaically generated. Do not modify it.
 #define KIWIX_{BASENAME}
 
 #include <string>
+#include <stdexcept>
 
 namespace RESOURCE {{
     {RESOURCES}
+}};
+
+class ResourceNotFound : public std::runtime_error {{
+  public:
+    ResourceNotFound(const std::string& what_arg):
+      std::runtime_error(what_arg)
+    {{ }};
 }};
 
 const std::string& getResource_{basename}(const std::string& name);


### PR DESCRIPTION
This is useless to raise an exception if the exception in not published
in the header.