### PR TITLE
Add small API to do geo query.

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -67,6 +67,10 @@ class Searcher
               unsigned int resultStart,
               unsigned int resultEnd,
               const bool verbose = false);
+  void geo_search(float latitude, float longitude, float distance,
+                  unsigned int resultStart,
+                  unsigned int resultEnd,
+                  const bool verbose = false);
   void suggestions(std::string& search, const bool verbose = false);
   Result* getNextResult();
   void restart_search();


### PR DESCRIPTION
This is a small quick and dirty API to do geo query.

It is not possible with this API to do a query search and a geo search.
It's either one or the other.

We should think about a better global API to do searching and provide
both of them in the same time (libzim does it).