### PR TITLE
Find ctpp2 lib in the normal lib dir and fallback to 'lib'.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,8 +48,14 @@ else
   ctpp2_include_args = ['-I'+ctpp2_include_path]
   if compiler.has_header('ctpp2/CTPP2Logger.hpp', args:ctpp2_include_args)
     ctpp2_include_dir = include_directories(ctpp2_include_path, is_system:true)
-    ctpp2_lib_path = ctpp2_prefix_install+'/lib'
-    ctpp2_lib = compiler.find_library('ctpp2', dirs:ctpp2_lib_path)
+    ctpp2_lib_path = join_paths(ctpp2_prefix_install, get_option('libdir'))
+    message(ctpp2_lib_path)
+    ctpp2_lib = compiler.find_library('ctpp2', dirs:ctpp2_lib_path, required:false)
+    if not ctpp2_lib.found()
+      ctpp2_lib_path = join_paths(ctpp2_prefix_install, 'lib')
+      message(ctpp2_lib_path)
+      ctpp2_lib = compiler.find_library('ctpp2', dirs:ctpp2_lib_path)
+    endif
     ctpp2_link_args = ['-L'+ctpp2_lib_path, '-lctpp2']
     if meson.is_cross_build() and host_machine.system() == 'windows'
       iconv_lib = compiler.find_library('iconv', required:false)


### PR DESCRIPTION
ctpp2 libs should be in the "normal" lib dir, so search in it.
The 'lib' dir should only be used as a fallback.