### PR TITLE
Set the RPATH of kiwix-lib.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -41,4 +41,5 @@ kiwixlib = library('kiwix',
                    dependencies : all_deps,
                    version: meson.project_version(),
                    install: true,
-                   install_dir: install_dir)
+                   install_dir: install_dir,
+                   install_rpath: '$ORIGIN')


### PR DESCRIPTION
As we cannot change (DY)LD_LIBRARY_PATH on macos, we have to use rpath.