### PR TITLE
Decode reserved characters in URLs

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -464,7 +464,7 @@ Entry Reader::getEntryFromPath(const std::string& path) const
 
 Entry Reader::getEntryFromEncodedPath(const std::string& path) const
 {
-  return getEntryFromPath(urlDecode(path));
+  return getEntryFromPath(urlDecode(path, true));
 }
 
 Entry Reader::getEntryFromTitle(const std::string& title) const


### PR DESCRIPTION
Fixes https://github.com/kiwix/kiwix-android/issues/633

The URLs in the ZIM file are formated ..../Book%3ACancer.... and the %3A is not decoded correctly at the moment.