### PR TITLE
Detect and reject infinite redirect loops.

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -122,6 +122,11 @@ Entry Entry::getFinalEntry() const
   if (final_article.good()) {
     return final_article;
   }
+  // Prevent infinite loops.
+  if (article.isRedirect() &&
+      article.getIndex() == article.getRedirectIndex()) {
+    throw noEntry();
+  }
 
   int loopCounter = 42;
   final_article = article;


### PR DESCRIPTION
This will prevent https://github.com/kiwix/kiwix-tools/issues/207, although it still doesn't address the fact that carrying on in kiwix-serve with a redirect entry ends up in a crash. It also doesn't explain how the writer created a file with a self-redirect in the first place.