### PR TITLE
Workaround a bug in meson 0.43.0 about custom_target's depend_files option.

### DIFF
--- a/static/meson.build
+++ b/static/meson.build
@@ -7,5 +7,5 @@ lib_resources = custom_target('resources',
              '--hfile', '@OUTPUT1@',
              '--source_dir', '@OUTDIR@',
              '@INPUT@'],
-    depend_files: 'static/search_result.tmpl'
+    depend_files: files('search_result.tmpl')
 )


### PR DESCRIPTION
There is a bug in meson 0.43.0 about the option depend_files
(mesonbuild/meson#2633)

By using the `files('search_result.tmpl')`, we workaround the bug and
have everything working whatever the meson version is.