### PR TITLE
Removed Rpath from compiled binaries

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -44,5 +44,4 @@ kiwixlib = library('kiwix',
                    dependencies : all_deps,
                    version: meson.project_version(),
                    install: true,
-                   install_dir: install_dir,
-                   install_rpath: '$ORIGIN')
+                   install_dir: install_dir)


### PR DESCRIPTION
Rpath is not needed to run installed binaries. Most of GNU/Linux distributions strictly forbid it.

See also:
 * https://lintian.debian.org/tags/binary-or-shlib-defines-rpath.html
 * https://wiki.debian.org/RpathIssue
 * https://docs.fedoraproject.org/en-US/packaging-guidelines/#_beware_of_rpath