### PR TITLE
Remove unused include unistd.h

### DIFF
--- a/src/tools/networkTools.cpp
+++ b/src/tools/networkTools.cpp
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <curl/curl.h>
 


### PR DESCRIPTION
We don't use it anymore and it is not present on Windows.