### PR TITLE
Fix crash searchbar's suggestions

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -772,6 +772,9 @@ bool Reader::searchSuggestionsSmart(const string& prefix,
     for (auto current = suggestionSearch->begin();
          current != suggestionSearch->end();
          current++) {
+      if (!current->good()) {
+          continue;
+      }
       std::vector<std::string> suggestion;
       suggestion.push_back(current->getTitle());
       suggestion.push_back("/A/" + current->getUrl());


### PR DESCRIPTION
The suggestion's list was filled without checking if the current suggestion
was wrong which caused crash in this case.

Fix https://github.com/kiwix/kiwix-desktop/issues/165
Fix https://github.com/kiwix/kiwix-tools/issues/299