### PR TITLE
Force the exit of the forked process.

### DIFF
--- a/src/subprocess_unix.cpp
+++ b/src/subprocess_unix.cpp
@@ -67,7 +67,7 @@ void UnixImpl::run(commandLine_t& commandLine)
       commandLine.push_back(NULL);
       if (execvp(binary, const_cast<char* const*>(commandLine.data()))) {
         perror("Cannot launch\n");
-        exit(-1);
+        _exit(-1);
       }
 
       break;


### PR DESCRIPTION
The `exit` function will call the functions registered.
Qt may (and does) register function and may (and does) hangup waiting
for some mutex to be free.

Here we are in a forked process and we want to process to exit without
doing any cleanup (because we are a clone of a process that will continue
and we don't want to mess it).