### PR TITLE
#239 ReLinker should be used to load library

### DIFF
--- a/android-kiwix-lib-publisher/kiwixLibAndroid/build.gradle
+++ b/android-kiwix-lib-publisher/kiwixLibAndroid/build.gradle
@@ -15,3 +15,7 @@ android {
         }
     }
 }
+
+dependencies {
+    implementation 'com.getkeepsafe.relinker:relinker:1.3.1'
+}

--- a/src/android/kiwixicu.cpp
+++ b/src/android/kiwixicu.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <jni.h>
-#include "org_kiwix_kiwixlib_JNIKiwix.h"
+#include "org_kiwix_kiwixlib_JNIICU.h"
 
 #include <iostream>
 #include <string>
@@ -30,7 +30,7 @@
 
 pthread_mutex_t globalLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
 
-JNIEXPORT void JNICALL Java_org_kiwix_kiwixlib_JNIKiwix_setDataDirectory(
+JNIEXPORT void JNICALL Java_org_kiwix_kiwixlib_JNIICU_setDataDirectory(
     JNIEnv* env, jobject obj, jstring dirStr)
 {
   std::string cPath = jni2c(dirStr, env);

--- a/src/android/meson.build
+++ b/src/android/meson.build
@@ -1,6 +1,6 @@
 
 kiwix_jni = custom_target('jni',
-  input: ['org/kiwix/kiwixlib/JNIKiwix.java',
+  input: ['org/kiwix/kiwixlib/JNIICU.java',
           'org/kiwix/kiwixlib/JNIKiwixReader.java',
           'org/kiwix/kiwixlib/JNIKiwixSearcher.java',
           'org/kiwix/kiwixlib/JNIKiwixInt.java',
@@ -16,7 +16,7 @@ kiwix_jni = custom_target('jni',
 )
 
 kiwix_sources += [
-    'android/kiwix.cpp',
+    'android/kiwixicu.cpp',
     'android/kiwixreader.cpp',
     'android/kiwixsearcher.cpp',
     kiwix_jni]

--- a/src/android/org/kiwix/kiwixlib/JNIICU.java
+++ b/src/android/org/kiwix/kiwixlib/JNIICU.java
@@ -20,17 +20,7 @@
 
 package org.kiwix.kiwixlib;
 
-import android.content.Context;
-import com.getkeepsafe.relinker.ReLinker;
-import org.kiwix.kiwixlib.JNIICU;
-
-public class JNIKiwix
+public class JNIICU
 {
-  public JNIKiwix(final Context context){
-    ReLinker.loadLibrary(context, "kiwix");
-  }
-
-  public void setDataDirectory(String icuDataDir) {
-    JNIICU.setDataDirectory(icuDataDir);
-  }
+  static public native void setDataDirectory(String icuDataDir);
 }


### PR DESCRIPTION
Try to fix #240

The thing is that we need to compile the java file to generate the JNI headers and compile kiwix-lib.so.
However, even if we are using javac, we are not in a "real" android environment and we don't have
the Relinker java module present.

But the constructor of `JNIKiwix` is not native and so, we don't need it when generating the JNI headers. By moving the native method `setIcuDataDirectory` in another class, we don't have to "compile" a plain java code.
We still install all java source file, so gradle will be able to "compile" the `JNIKiwix.java` correctly.

I've not tested with android application, but `.aar`