### PR TITLE
[JNI] Fix implementation of setDataDirectory.

### DIFF
--- a/src/android/kiwixicu.cpp
+++ b/src/android/kiwixicu.cpp
@@ -31,7 +31,7 @@
 pthread_mutex_t globalLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
 
 JNIEXPORT void JNICALL Java_org_kiwix_kiwixlib_JNIICU_setDataDirectory(
-    JNIEnv* env, jobject obj, jstring dirStr)
+    JNIEnv* env, jclass kclass, jstring dirStr)
 {
   std::string cPath = jni2c(dirStr, env);
 


### PR DESCRIPTION
Now that setDataDirectory is a static method, we need to take an
jclass instead of a jobject.