### PR TITLE
Fix fulltext search link in kiwix-serve suggestions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 kiwix-lib 6.0.3
 ===============
 
+ * fix fulltext search link in suggestions
  * UI fixes in kiwix-serve rendering
 
 kiwix-lib 6.0.2

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -519,7 +519,7 @@ Response InternalServer::handle_suggest(const RequestContext& request)
   if (reader->hasFulltextIndex()) {
     kainjow::mustache::data result;
     result.set("label", "containing '" + term + "'...");
-    result.set("value", term);
+    result.set("value", term + " ");
     result.set("first", first);
     results.push_back(result);
   }


### PR DESCRIPTION
Fix https://github.com/kiwix/kiwix-tools/issues/331