### PR TITLE
Correctly cast double to int.

### DIFF
--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -108,7 +108,7 @@ std::string SearchRenderer::getHtml()
       pageEnd = estimatedResultCount / resultCountPerPage;
     }
     if (estimatedResultCount > resultCountPerPage) {
-      lastPageStart = round(estimatedResultCount/resultCountPerPage) * resultCountPerPage;
+      lastPageStart = static_cast<int>(round(estimatedResultCount/resultCountPerPage)) * resultCountPerPage;
     }
   }
 


### PR DESCRIPTION
Ms cl compiler complains about the implicit conversion.