### PR TITLE
[ABI Break] Correctly detect the executable path in appimage.

### DIFF
--- a/include/tools/pathTools.h
+++ b/include/tools/pathTools.h
@@ -38,7 +38,7 @@ bool makeDirectory(const std::string& path);
 std::string makeTmpDirectory();
 bool copyFile(const std::string& sourcePath, const std::string& destPath);
 std::string getLastPathElement(const std::string& path);
-std::string getExecutablePath();
+std::string getExecutablePath(bool realPathOnly = false);
 std::string getCurrentDirectory();
 std::string getDataDirectory();
 bool writeTextFile(const std::string& path, const std::string& content);

--- a/src/aria2.cpp
+++ b/src/aria2.cpp
@@ -49,7 +49,7 @@ Aria2::Aria2():
   m_secret = "token:"+m_secret;
 
   std::string aria2cmd = appendToDirectory(
-    removeLastPathElement(getExecutablePath(), true, true),
+    removeLastPathElement(getExecutablePath(true), true, true),
     ARIA2_CMD);
   if (fileExists(aria2cmd)) {
     // A local aria2c exe exists (packaged with kiwix-desktop), use it.

--- a/src/kiwixserve.cpp
+++ b/src/kiwixserve.cpp
@@ -36,7 +36,7 @@ void KiwixServe::run()
 
     std::vector<const char*> callCmd;
     std::string kiwixServeCmd = appendToDirectory(
-        removeLastPathElement(getExecutablePath(), true, true),
+        removeLastPathElement(getExecutablePath(true), true, true),
         KIWIXSERVE_CMD);
     if (fileExists(kiwixServeCmd)) {
         // A local kiwix-serve exe exists (packaged with kiwix-desktop), use it.

--- a/src/tools/pathTools.cpp
+++ b/src/tools/pathTools.cpp
@@ -279,24 +279,20 @@ bool copyFile(const std::string& sourcePath, const std::string& destPath)
   return true;
 }
 
-std::string getExecutablePath()
+std::string getExecutablePath(bool realPathOnly)
 {
   char binRootPath[PATH_MAX];
 
-  char* cAppImage = ::getenv("APPIMAGE");
-  if (cAppImage) {
-    char* cArgv0 = ::getenv("ARGV0");
-    char* cOwd = ::getenv("OWD");
-    if (!cArgv0 && !cOwd) {
-      // Nothing to clean, goto in the same function...
-      // This is silly but .. ok..
-      // And we should pass here, if APPIMAGE is set ARGV0 and OWD should also
-      // (except if there is a bug in appimage)
-      goto normal;
+  if (!realPathOnly) {
+    char* cAppImage = ::getenv("APPIMAGE");
+    if (cAppImage) {
+      char* cArgv0 = ::getenv("ARGV0");
+      char* cOwd = ::getenv("OWD");
+      if (cArgv0 && cOwd) {
+        return appendToDirectory(cOwd, cArgv0);
+      }
     }
-    return appendToDirectory(cOwd, cArgv0);
   }
-normal:
 
 #ifdef _WIN32
   GetModuleFileName(NULL, binRootPath, PATH_MAX);


### PR DESCRIPTION
There are two executable path :
- The user one (the appimage path)
- The real one (in the appimage archive)

When we search of `library.xml` we need the user one.
But when we search of `aria2c` or `kiwix-serve` we need the real one.

Fix kiwix/kiwix-desktop#256