### PR TITLE
Add a parameter to getBookmarks fct to get valid bookmarks only

### DIFF
--- a/include/library.h
+++ b/include/library.h
@@ -208,7 +208,7 @@ class Library
    *
    * @return A list of bookmarks
    */
-  const std::vector<kiwix::Bookmark>& getBookmarks() { return m_bookmarks; }
+  const std::vector<kiwix::Bookmark> getBookmarks(bool onlyValidBookmarks = true);
 
   /**
    * Get all book ids of the books in the library.

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -184,6 +184,21 @@ std::vector<std::string> Library::getBooksPublishers()
   return booksPublishers;
 }
 
+const std::vector<kiwix::Bookmark> Library::getBookmarks(bool onlyValidBookmarks)
+{
+  if (!onlyValidBookmarks) {
+    return m_bookmarks;
+  }
+  std::vector<kiwix::Bookmark> validBookmarks;
+  auto booksId = getBooksIds();
+  for(auto& bookmark:m_bookmarks) {
+    if (std::find(booksId.begin(), booksId.end(), bookmark.getBookId()) != booksId.end()) {
+      validBookmarks.push_back(bookmark);
+    }
+  }
+  return validBookmarks;
+}
+
 std::vector<std::string> Library::getBooksIds()
 {
   std::vector<std::string> bookIds;

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -180,6 +180,7 @@ const char * sampleOpdsStream = R"(
 
 #include "../include/library.h"
 #include "../include/manager.h"
+#include "../include/bookmark.h"
 
 namespace
 {
@@ -191,8 +192,33 @@ class LibraryTest : public ::testing::Test {
      manager.readOpds(sampleOpdsStream, "foo.urlHost");
   }
 
+    kiwix::Bookmark createBookmark(const std::string &id) {
+        kiwix::Bookmark bookmark;
+        bookmark.setBookId(id);
+        return bookmark;
+    };
+
   kiwix::Library lib;
 };
+
+TEST_F(LibraryTest, getBookMarksTest)
+{    
+    auto bookId1 = lib.getBooksIds()[0];
+    auto bookId2 = lib.getBooksIds()[1];
+
+    lib.addBookmark(createBookmark(bookId1));
+    lib.addBookmark(createBookmark("invalid-bookmark-id"));
+    lib.addBookmark(createBookmark(bookId2));
+    auto onlyValidBookmarks = lib.getBookmarks();
+    auto allBookmarks = lib.getBookmarks(false);
+
+    EXPECT_EQ(onlyValidBookmarks[0].getBookId(), bookId1);
+    EXPECT_EQ(onlyValidBookmarks[1].getBookId(), bookId2);
+
+    EXPECT_EQ(allBookmarks[0].getBookId(), bookId1);
+    EXPECT_EQ(allBookmarks[1].getBookId(), "invalid-bookmark-id");
+    EXPECT_EQ(allBookmarks[2].getBookId(), bookId2);
+}
 
 TEST_F(LibraryTest, sanityCheck)
 {


### PR DESCRIPTION
The default value of this parameter is false, in this case all the bookmarks
are returned, otherwise only those who are related to books of the library.