### PR TITLE
Implement Open Search in content

### DIFF
--- a/include/opds_dumper.h
+++ b/include/opds_dumper.h
@@ -31,6 +31,8 @@
 #include "tools/regexTools.h"
 #include "library.h"
 #include "reader.h"
+#include "searcher.h"
+#include "name_mapper.h"
 
 using namespace std;
 
@@ -100,6 +102,48 @@ class OPDSDumper
    */
   void setLibrary(Library* library) { this->library = library; }
 
+  /**
+   * Set the search pattern.
+   *
+   * @param library The library to dump.
+   */
+  void setSearchPattern(const std::string& searchPattern) { this->searchPattern = searchPattern; }
+
+  /**
+   * Set the protocol prefix.
+   *
+   * @param library The library to dump.
+   */
+  void setSearchProtocolPrefix(const std::string& searchProtocolPrefix) { this->searchProtocolPrefix = searchProtocolPrefix; }
+
+  /**
+   * Set the search pattern.
+   *
+   * @param library The library to dump.
+   */
+  void setProtocolPrefix(const std::string& protocolPrefix) { this->protocolPrefix = protocolPrefix; }
+
+  /**
+   * Set the result count per page
+   **/
+  void setResultCountPerPage(const unsigned int resultCountPerPage) { this->resultCountPerPage = resultCountPerPage; }
+
+  /**
+   * Set the estimated result count
+   **/
+  void setEstimatedResultCount(const unsigned int estimatedResultCount) { this->estimatedResultCount = estimatedResultCount; }
+
+  /**
+   * Set the result start
+   **/
+  void setResultStart(const unsigned int resultStart) { this->resultStart = resultStart; }
+
+  /**
+   * Dump the OPDS Search result feed
+   * @param searcher The searcher object allowing to retrieve results
+   **/ 
+  std::string dumpSearchResultFeed(Searcher& searcher, NameMapper& nameMapper);
+
  protected:
   kiwix::Library* library;
   std::string id;
@@ -107,6 +151,12 @@ class OPDSDumper
   std::string date;
   std::string rootLocation;
   std::string searchDescriptionUrl;
+  std::string searchPattern;
+  std::string searchProtocolPrefix;
+  std::string protocolPrefix;
+  unsigned int resultCountPerPage;
+  unsigned int estimatedResultCount;
+  unsigned int resultStart;
   int m_totalResults;
   int m_startIndex;
   int m_count;
@@ -114,6 +164,7 @@ class OPDSDumper
 
  private:
   pugi::xml_node handleBook(Book book, pugi::xml_node root_node);
+  pugi::xml_node handleResultEntry(const std::string& uid, Result* result, pugi::xml_node& root_node, NameMapper& nameMapper);
 };
 }
 

--- a/include/search_renderer.h
+++ b/include/search_renderer.h
@@ -21,6 +21,7 @@
 #define KIWIX_SEARCH_RENDERER_H
 
 #include <string>
+#include "opds_dumper.h"
 
 namespace kiwix
 {
@@ -61,9 +62,19 @@ class SearchRenderer
   void setSearchProtocolPrefix(const std::string& prefix);
 
   /**
-   * Generate the html page with the resutls of the search.
+   * Set the search description url for atom feed generation 
+   **/
+  void setSearchDescriptionUrl(const std::string& url);
+
+  /**
+   * Generate the html page with the results of the search.
    */
   std::string getHtml();
+
+  /**
+   * Generate the atom feed with the results of the search.
+   */
+  std::string getAtomFeed();
 
  protected:
   std::string beautifyInteger(const unsigned int number);
@@ -73,6 +84,7 @@ class SearchRenderer
   std::string searchPattern;
   std::string protocolPrefix;
   std::string searchProtocolPrefix;
+  std::string searchDescriptionUrl;
   unsigned int resultCountPerPage;
   unsigned int estimatedResultCount;
   unsigned int resultStart;

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -168,7 +168,6 @@ std::string SearchRenderer::getAtomFeed() {
   opdsDumper.setSearchDescriptionUrl("search/searchdescription.xml");
 
   return opdsDumper.dumpSearchResultFeed(*mp_searcher, *mp_nameMapper);
-
 }
 
 

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -66,6 +66,11 @@ void SearchRenderer::setSearchProtocolPrefix(const std::string& prefix)
   this->searchProtocolPrefix = prefix;
 }
 
+void SearchRenderer::setSearchDescriptionUrl(const std::string& searchDescriptionUrl)
+{
+  this->searchDescriptionUrl = searchDescriptionUrl;
+}
+
 std::string SearchRenderer::getHtml()
 {
   kainjow::mustache::data results{kainjow::mustache::data::type::list};
@@ -148,5 +153,23 @@ std::string SearchRenderer::getHtml()
   tmpl.render(allData, [&ss](const std::string& str) { ss << str; });
   return ss.str();
 }
+
+
+std::string SearchRenderer::getAtomFeed() {
+  mp_searcher->restart_search();
+  kiwix::OPDSDumper opdsDumper;
+
+  opdsDumper.setSearchDescriptionUrl(this->searchDescriptionUrl);
+  opdsDumper.setSearchPattern(this->searchPattern);
+  opdsDumper.setResultCountPerPage(this->resultCountPerPage);
+  opdsDumper.setEstimatedResultCount(this->estimatedResultCount);
+  opdsDumper.setResultStart(this->resultStart);
+  opdsDumper.setProtocolPrefix(this->protocolPrefix);
+  opdsDumper.setSearchDescriptionUrl("search/searchdescription.xml");
+
+  return opdsDumper.dumpSearchResultFeed(*mp_searcher, *mp_nameMapper);
+
+}
+
 
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -707,7 +707,6 @@ Response InternalServer::handle_search_results(const RequestContext& request)
     else {
       response.set_content(renderer.getHtml());
     }
-
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
   }
@@ -737,7 +736,6 @@ Response InternalServer::handle_search(const RequestContext& request)
   else {
     return this->handle_search_results(request);
   }
-
 }
 
 Response InternalServer::handle_random(const RequestContext& request)

--- a/static/contentOpensearchDescription.xml
+++ b/static/contentOpensearchDescription.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Zim content search</ShortName>
+  <Description>Search zim content in the library.</Description>
+  <Url type="application/atom+xml" 
+       xmlns:atom="http://www.w3.org/2005/Atom"
+       indexOffset="0"
+       template="/{{root}}/search?pattern={searchTerms}&amp;lang={language}&amp;count={count}&amp;start={startIndex}"/>
+</OpenSearchDescription>

--- a/static/resources_list.txt
+++ b/static/resources_list.txt
@@ -29,3 +29,4 @@ templates/suggestion.json
 templates/head_part.html
 templates/taskbar_part.html
 opensearchdescription.xml
+contentOpensearchDescription.xml


### PR DESCRIPTION
Provides Open Search endpoints to search into content and retrieve results thanks to an Atom feed.

Fixes https://github.com/kiwix/kiwix-tools/issues/52