### PR TITLE
Fix tests.

### DIFF
--- a/test/kiwixserve.cpp
+++ b/test/kiwixserve.cpp
@@ -10,9 +10,3 @@ TEST(KiwixServeTest, PortTest)
     EXPECT_EQ(kiwixServe.setPort(0), -1);
     EXPECT_EQ(kiwixServe.setPort(3456789), -1);
 }
-
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -259,9 +259,3 @@ TEST_F(LibraryTest, filterCheck)
 
 }
 };
-
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/meson.build
+++ b/test/meson.build
@@ -13,7 +13,7 @@ tests = [
 
 gtest_dep = dependency('gtest',
                        main:true,
-                       fallback: ['gtest', 'gtest_dep'],
+                       fallback: ['gtest', 'gtest_main_dep'],
                        required:false)
 
 if gtest_dep.found()

--- a/test/parseUrl.cpp
+++ b/test/parseUrl.cpp
@@ -65,9 +65,3 @@ TEST(ParseUrlTest, valid)
   ASSERT_EQ(title, "/title");
 }
 };
-
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/pathTools.cpp
+++ b/test/pathTools.cpp
@@ -227,8 +227,3 @@ TEST(pathTools, WideToUtf8)
 
 
 };
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/regex.cpp
+++ b/test/regex.cpp
@@ -101,9 +101,3 @@ TEST(append, middle)
 }
 
 };
-
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/stringTools.cpp
+++ b/test/stringTools.cpp
@@ -54,8 +54,3 @@ TEST(stringTools, split)
 }
 
 };
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/tagParsing.cpp
+++ b/test/tagParsing.cpp
@@ -95,8 +95,3 @@ TEST(ParseTagTest, invalid)
 }
 
 };
-int main(int argc, char** argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
As we use the main library of gtest (if already installed)
we don't need to (and must not) define a main function for the tests.

Does the same (use main library) if we use the subproject.