### PR TITLE
Add parameter options to start a download with aria2

### DIFF
--- a/include/downloader.h
+++ b/include/downloader.h
@@ -92,7 +92,7 @@ class Downloader
 
   void close();
 
-  Download* startDownload(const std::string& uri);
+  Download* startDownload(const std::string& uri, const std::vector<std::pair<std::string, std::string>>& options = {});
   Download* getDownload(const std::string& did);
 
   size_t getNbDownload() { return m_knownDownloads.size(); }

--- a/src/aria2.cpp
+++ b/src/aria2.cpp
@@ -160,12 +160,15 @@ std::string Aria2::doRequest(const MethodCall& methodCall)
   throw std::runtime_error("Cannot perform request");
 }
 
-std::string Aria2::addUri(const std::vector<std::string>& uris)
+std::string Aria2::addUri(const std::vector<std::string>& uris, const std::vector<std::pair<std::string, std::string>>& options)
 {
   MethodCall methodCall("aria2.addUri", m_secret);
   auto uriParams = methodCall.newParamValue().getArray();
   for (auto& uri : uris) {
     uriParams.addValue().set(uri);
+  }
+  for (auto& option : options) {
+    methodCall.newParamValue().getStruct().addMember(option.first).getValue().set(option.second);
   }
   auto ret = doRequest(methodCall);
   MethodResponse response(ret);

--- a/src/aria2.h
+++ b/src/aria2.h
@@ -34,7 +34,7 @@ class Aria2
     virtual ~Aria2();
     void close();
 
-    std::string addUri(const std::vector<std::string>& uri);
+    std::string addUri(const std::vector<std::string>& uri, const std::vector<std::pair<std::string, std::string>>& options = {});
     std::string tellStatus(const std::string& gid, const std::vector<std::string>& statusKey);
     std::vector<std::string> tellActive();
     std::vector<std::string> tellWaiting();

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -163,7 +163,7 @@ std::vector<std::string> Downloader::getDownloadIds() {
   return ret;
 }
 
-Download* Downloader::startDownload(const std::string& uri)
+Download* Downloader::startDownload(const std::string& uri, const std::vector<std::pair<std::string, std::string>>& options)
 {
   for (auto& p: m_knownDownloads) {
     auto& d = p.second;
@@ -172,7 +172,7 @@ Download* Downloader::startDownload(const std::string& uri)
       return d.get();
   }
   std::vector<std::string> uris = {uri};
-  auto gid = mp_aria->addUri(uris);
+  auto gid = mp_aria->addUri(uris, options);
   m_knownDownloads[gid] = std::unique_ptr<Download>(new Download(mp_aria, gid));
   return m_knownDownloads[gid].get();
 }


### PR DESCRIPTION
Downloader::startDownload has a new parameter option which is a vector of pair that represents the options that can be set for adding a uri with aria2 with the function Aria2::addUri.

Aria2::addUri uses this parameter to set the struct of parameters for the aria2 command