### PR TITLE
attach taskbar to <head> instead of <head>\n

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -117,7 +117,7 @@ void Response::introduce_taskbar()
   auto head_content = render_template(RESOURCE::templates::head_part_html, data);
   m_content = appendToFirstOccurence(
     m_content,
-    "<head>\n",
+    "<head>",
     head_content);
 
   auto taskbar_part = render_template(RESOURCE::templates::taskbar_part_html, data);
@@ -135,7 +135,7 @@ void Response::inject_externallinks_blocker()
   auto script_tag = render_template(RESOURCE::templates::external_blocker_part_html, data);
   m_content = appendToFirstOccurence(
     m_content,
-    "<head>\n",
+    "<head>",
     script_tag);
 }
 


### PR DESCRIPTION
Fixed a regression introduced in block-external-links feature.

For cleaner source, the taskbar (and the block-external JS file) were both
attached to `<head>\n`.
Unfortunately, this isn't safe enough as some ZIM files might have all kinds of HTML
syntax. Sotoki for instance have no CR after head, rendering the attachment impossible.

Note: realizing this method is somehow fragile as any HTML content with extra attribute
on the `<head>` tag or without a `<head>` tag would break the taskbar and the block external feature.