### PR TITLE
Fix datadir windows

### DIFF
--- a/src/tools/pathTools.cpp
+++ b/src/tools/pathTools.cpp
@@ -435,6 +435,7 @@ std::string getDataDirectory()
 #endif
   if (!dataDir.empty()) {
     dataDir = appendToDirectory(dataDir, "kiwix");
+    makeDirectory(dataDir);
     return dataDir;
   }
 


### PR DESCRIPTION
This fix kiwix/kiwix-desktop#409 (among others).

Note that this PR also change the default data dir on windows and fix #275.
However, there is nothing to move the content to the new location.
The user will have to move itself the data from `c:\Users\<user>\AppData\Roaming` to `c:\Users\<user>\AppData\Roaming\kiwix`.

We may want to do something to handle this case, but it's better done on kiwix-desktop side (if no library is present, check on old dataDirectory and move things if necessary).