### PR TITLE
Support for HTTP HEAD method, ETags, and If-None-Match conditional requests

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -21,6 +21,7 @@ kiwix_sources = [
   'tools/otherTools.cpp',
   'kiwixserve.cpp',
   'name_mapper.cpp',
+  'server/etag.cpp',
   'server/request_context.cpp',
   'server/response.cpp'
 ]

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -301,7 +301,8 @@ int InternalServer::handlerCallback(struct MHD_Connection* connection,
   }
   /* Unexpected method */
   if (request.get_method() != RequestMethod::GET
-   && request.get_method() != RequestMethod::POST) {
+   && request.get_method() != RequestMethod::POST
+   && request.get_method() != RequestMethod::HEAD) {
     printf("Reject request because of unhandled request method.\n");
     printf("----------------------\n");
     return MHD_NO;

--- a/src/server/etag.cpp
+++ b/src/server/etag.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+
+#include "etag.h"
+
+#include <algorithm>
+
+namespace kiwix {
+
+namespace {
+
+// Characters in the options part of the ETag could in principle be picked up
+// from the latin alphabet in natural order (the character corresponding to
+// ETag::Option opt would be 'a'+opt; that would somewhat simplify the code in
+// this file). However it is better to have some mnemonics in the option names,
+// hence below variable: all_options[opt] corresponds to the character going
+// into the ETag for ETag::Option opt.
+const char all_options[] = "cz";
+
+static_assert(ETag::OPTION_COUNT == sizeof(all_options) - 1, "");
+
+} // namespace
+
+
+void ETag::set_option(Option opt)
+{
+  if ( ! get_option(opt) )
+  {
+    m_options.push_back(all_options[opt]);
+    std::sort(m_options.begin(), m_options.end());
+  }
+}
+
+bool ETag::get_option(Option opt) const
+{
+  return m_options.find(all_options[opt]) != std::string::npos;
+}
+
+std::string ETag::get_etag() const
+{
+  if ( m_serverId.empty() )
+    return std::string();
+
+  return "\"" + m_serverId + "/" + m_options + "\"";
+}
+
+} // namespace kiwix

--- a/src/server/etag.h
+++ b/src/server/etag.h
@@ -67,6 +67,14 @@ class ETag
     bool get_option(Option opt) const;
     std::string get_etag() const;
 
+
+    static ETag match(const std::string& etags, const std::string& server_id);
+
+  private: // functions
+    ETag(const std::string& serverId, const std::string& options);
+
+    static ETag parse(std::string s);
+
   private: // data
     std::string m_serverId;
     std::string m_options;

--- a/src/server/etag.h
+++ b/src/server/etag.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+
+#ifndef KIWIXLIB_SERVER_ETAG_H
+#define KIWIXLIB_SERVER_ETAG_H
+
+#include <string>
+
+namespace kiwix {
+
+// The ETag string used by Kiwix server (more precisely, its value inside the
+// double quotes) consists of two parts:
+//
+// 1. ServerId - The string obtained on server start up
+//
+// 2. Options -  Zero or more characters encoding the values of some of the
+//               headers of the response
+//
+// The two parts are separated with a slash (/) symbol (which is always present,
+// even when the the options part is empty). Neither portion of a Kiwix ETag
+// may contain the slash symbol.
+// Examples of valid Kiwix server ETags (including the double quotes):
+//
+//   "abcdefghijklmn/"
+//   "1234567890/z"
+//   "1234567890/cz"
+//
+// The options part of the Kiwix ETag allows to correctly set the required
+// headers when responding to a conditional If-None-Match request with a 304
+// (Not Modified) response without following the full code path that would
+// discover the necessary options.
+
+class ETag
+{
+  public: // types
+    enum Option {
+      CACHEABLE_ENTITY,
+      COMPRESSED_CONTENT,
+      OPTION_COUNT
+    };
+
+  public: // functions
+    ETag() {}
+
+    void set_server_id(const std::string& id) { m_serverId = id; }
+    void set_option(Option opt);
+
+    explicit operator bool() const { return !m_serverId.empty(); }
+
+    bool get_option(Option opt) const;
+    std::string get_etag() const;
+
+  private: // data
+    std::string m_serverId;
+    std::string m_options;
+};
+
+} // namespace kiwix
+
+#endif // KIWIXLIB_SERVER_ETAG_H

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -209,6 +209,12 @@ Response::create_raw_content_mhd_response(const RequestContext& request)
   MHD_Response* response = MHD_create_response_from_buffer(
     m_content.size(), const_cast<char*>(m_content.data()), MHD_RESPMEM_MUST_COPY);
 
+  // At shis point m_etag.get_option(ETag::COMPRESSED_CONTENT) and
+  // shouldCompress can have different values. This can happen for a 304 (Not
+  // Modified) response generated while handling a conditional If-None-Match
+  // request. In that case the m_etag (together with its COMPRESSED_CONTENT
+  // option) is obtained from the ETag list of the If-None-Match header and the
+  // response has no body (which shouldn't be compressed).
   if ( m_etag.get_option(ETag::COMPRESSED_CONTENT) ) {
     MHD_add_response_header(
         response, MHD_HTTP_HEADER_VARY, "Accept-Encoding");

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -55,7 +55,6 @@ Response::Response(const std::string& root, bool verbose, bool withTaskbar, bool
     m_withTaskbar(withTaskbar),
     m_withLibraryButton(withLibraryButton),
     m_blockExternalLinks(blockExternalLinks),
-    m_useCache(false),
     m_addTaskbar(false),
     m_bookName(""),
     m_startRange(0),
@@ -168,6 +167,14 @@ void Response::inject_externallinks_blocker()
     script_tag);
 }
 
+bool
+Response::can_compress(const RequestContext& request) const
+{
+  return request.can_compress()
+      && is_compressible_mime_type(m_mimeType)
+      && (m_content.size() > KIWIX_MIN_CONTENT_SIZE_TO_DEFLATE);
+}
+
 MHD_Response*
 Response::create_raw_content_mhd_response(const RequestContext& request)
 {
@@ -178,10 +185,7 @@ Response::create_raw_content_mhd_response(const RequestContext& request)
     inject_externallinks_blocker();
   }
 
-  bool shouldCompress = m_compress && request.can_compress();
-  shouldCompress &= is_compressible_mime_type(m_mimeType);
-  shouldCompress &= (m_content.size() > KIWIX_MIN_CONTENT_SIZE_TO_DEFLATE);
-
+  bool shouldCompress = m_compress && can_compress(request);
   if (shouldCompress) {
     std::vector<Bytef> compr_buffer(compressBound(m_content.size()));
     uLongf comprLen = compr_buffer.capacity();
@@ -196,6 +200,7 @@ Response::create_raw_content_mhd_response(const RequestContext& request)
          It has no incidence on other browsers
          See http://www.subbu.org/blog/2008/03/ie7-deflate-or-not and comments */
       m_content = string((char*)&compr_buffer[2], comprLen - 2);
+      m_etag.set_option(ETag::COMPRESSED_CONTENT);
     } else {
       shouldCompress = false;
     }
@@ -204,9 +209,11 @@ Response::create_raw_content_mhd_response(const RequestContext& request)
   MHD_Response* response = MHD_create_response_from_buffer(
     m_content.size(), const_cast<char*>(m_content.data()), MHD_RESPMEM_MUST_COPY);
 
-  if (shouldCompress) {
+  if ( m_etag.get_option(ETag::COMPRESSED_CONTENT) ) {
     MHD_add_response_header(
         response, MHD_HTTP_HEADER_VARY, "Accept-Encoding");
+  }
+  if (shouldCompress) {
     MHD_add_response_header(
         response, MHD_HTTP_HEADER_CONTENT_ENCODING, "deflate");
   }
@@ -267,7 +274,10 @@ int Response::send(const RequestContext& request, MHD_Connection* connection)
 
   MHD_add_response_header(response, "Access-Control-Allow-Origin", "*");
   MHD_add_response_header(response, MHD_HTTP_HEADER_CACHE_CONTROL,
-    m_useCache ? "max-age=2723040, public" : "no-cache, no-store, must-revalidate");
+    m_etag.get_option(ETag::CACHEABLE_ENTITY) ? "max-age=2723040, public" : "no-cache, no-store, must-revalidate");
+  const std::string etag = m_etag.get_etag();
+  if ( ! etag.empty() )
+      MHD_add_response_header(response, MHD_HTTP_HEADER_ETAG, etag.c_str());
 
   if (m_returnCode == MHD_HTTP_OK && request.has_range())
     m_returnCode = MHD_HTTP_PARTIAL_CONTENT;
@@ -301,7 +311,7 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
 
   const std::string mimeType = get_mime_type(entry);
   set_mimeType(mimeType);
-  set_cache(true);
+  set_cacheable();
 
   if ( is_compressible_mime_type(mimeType) ) {
     zim::Blob raw_content = entry.getBlob();

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -25,6 +25,7 @@
 
 #include <mustache.hpp>
 #include "entry.h"
+#include "etag.h"
 
 extern "C" {
 #include <microhttpd.h>
@@ -55,17 +56,21 @@ class Response {
 
     void set_mimeType(const std::string& mimeType) { m_mimeType = mimeType; }
     void set_code(int code) { m_returnCode = code; }
-    void set_cache(bool cache) { m_useCache = cache; }
+    void set_cacheable() { m_etag.set_option(ETag::CACHEABLE_ENTITY); }
+    void set_server_id(const std::string& id) { m_etag.set_server_id(id); }
+    void set_etag(const ETag& etag) { m_etag = etag; }
     void set_compress(bool compress) { m_compress = compress; }
     void set_taskbar(const std::string& bookName, const std::string& bookTitle);
     void set_range_first(uint64_t start) { m_startRange = start; }
     void set_range_len(uint64_t len) { m_lenRange = len; }
 
-    int getReturnCode() { return m_returnCode; }
+    int getReturnCode() const { return m_returnCode; }
     std::string get_mimeType() const { return m_mimeType; }
 
     void introduce_taskbar();
     void inject_externallinks_blocker();
+
+    bool can_compress(const RequestContext& request) const;
 
   private: // functions
     MHD_Response* create_mhd_response(const RequestContext& request);
@@ -84,13 +89,13 @@ class Response {
     bool m_withTaskbar;
     bool m_withLibraryButton;
     bool m_blockExternalLinks;
-    bool m_useCache;
     bool m_compress;
     bool m_addTaskbar;
     std::string m_bookName;
     std::string m_bookTitle;
     uint64_t m_startRange;
     uint64_t m_lenRange;
+    ETag m_etag;
 };
 
 }


### PR DESCRIPTION
Will fix kiwix/kiwix-tools#140

This is the last batch of commits from #340 following #344 and #345.

It is easier to review this PR one commit at a time.

Implementation of the support for the HEAD request method is far from optimal. It executes all of the code of the GET request method and then discards the body. This optimizes the traffic but not the server CPU usage. However, if clients properly take advantage of ETags set by the server they should NOT abuse HEAD requests, but issue conditional GET requests with the If-None-Match header set to the value of the ETag from the response to the original GET request.

Implementation-wise the ETag string used by Kiwix server (more precisely, its value inside the double quotes) consists of two parts:

1. ServerId - A "unique" string obtained on server start up
2. Options -  Zero or more characters encoding the values of some of the headers of the response

The two parts are separated with a slash (/) symbol (which is always present, even when the the options part is empty). Neither portion of a Kiwix ETag may contain the slash symbol.

Examples of valid Kiwix server ETags (including the double quotes):

  "abcdefghijklmn/"
  "1234567890/z"
  "1234567890/cz"

The options part of the Kiwix ETag allows to correctly set the required headers when responding to a conditional If-None-Match request with a 304 (Not Modified) response without following the full code path that would discover the necessary options.

This PR comes with a set of new unit-tests covering the changes almost fully (several omitted edge cases related to invalid and weak ETags in the If-None-Match header leave a couple of lines uncovered).