### PR TITLE
Use python3 instead of python.

### DIFF
--- a/static/meson.build
+++ b/static/meson.build
@@ -1,4 +1,4 @@
-resource_files = run_command(find_program('python'),
+resource_files = run_command(find_program('python3'),
                     '-c',
                     'import sys; f=open(sys.argv[1]); print(f.read())',
                     files('resources_list.txt')


### PR DESCRIPTION
`python` binary is not installed on all platform.
But `python3` is (because meson is python3).
And the script we launch is python3 so use the correct version.