### PR TITLE
Fixed the support for byte range requests

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -21,6 +21,7 @@ kiwix_sources = [
   'tools/otherTools.cpp',
   'kiwixserve.cpp',
   'name_mapper.cpp',
+  'server/byte_range.cpp',
   'server/etag.cpp',
   'server/request_context.cpp',
   'server/response.cpp'

--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+
+#include "byte_range.h"
+
+namespace kiwix {
+
+ByteRange::ByteRange()
+  : kind_(NONE)
+  , first_(0)
+  , last_(-1)
+{}
+
+ByteRange::ByteRange(Kind kind, int64_t first, int64_t last)
+  : kind_(kind)
+  , first_(first)
+  , last_(last)
+{}
+
+} // namespace kiwix

--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -20,6 +20,8 @@
 
 #include "byte_range.h"
 
+#include "tools/stringTools.h"
+
 namespace kiwix {
 
 ByteRange::ByteRange()
@@ -33,5 +35,31 @@ ByteRange::ByteRange(Kind kind, int64_t first, int64_t last)
   , first_(first)
   , last_(last)
 {}
+
+ByteRange ByteRange::parse(std::string rangeStr)
+{
+  ByteRange byteRange;
+  const std::string byteUnitSpec("bytes=");
+  if ( kiwix::startsWith(rangeStr, byteUnitSpec) ) {
+    rangeStr.erase(0, byteUnitSpec.size());
+    std::istringstream iss(rangeStr);
+
+    int64_t start, end = INT64_MAX;
+    if (iss >> start) {
+      if ( start < 0 ) {
+        if ( iss.eof() )
+          byteRange = ByteRange(ByteRange::PARSED, start, end);
+      } else {
+        char c;
+        if (iss >> c && c=='-') {
+          iss >> end; // if this fails, end is not modified, which is OK
+          if (iss.eof())
+            byteRange = ByteRange(ByteRange::PARSED, start, end);
+        }
+      }
+    }
+  }
+  return byteRange;
+}
 
 } // namespace kiwix

--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -25,7 +25,7 @@ namespace kiwix {
 ByteRange::ByteRange()
   : kind_(NONE)
   , first_(0)
-  , last_(-1)
+  , last_(INT64_MAX)
 {}
 
 ByteRange::ByteRange(Kind kind, int64_t first, int64_t last)

--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -48,13 +48,13 @@ ByteRange ByteRange::parse(std::string rangeStr)
     if (iss >> start) {
       if ( start < 0 ) {
         if ( iss.eof() )
-          byteRange = ByteRange(ByteRange::PARSED, start, end);
+          byteRange = ByteRange(PARSED, start, end);
       } else {
         char c;
         if (iss >> c && c=='-') {
           iss >> end; // if this fails, end is not modified, which is OK
           if (iss.eof() && start <= end)
-            byteRange = ByteRange(ByteRange::PARSED, start, end);
+            byteRange = ByteRange(PARSED, start, end);
         }
       }
     }

--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -85,6 +85,9 @@ ByteRange ByteRange::resolve(int64_t contentSize) const
 
   const int64_t resolved_last = std::min(contentSize-1, last());
 
+  if ( resolved_first > resolved_last )
+    return ByteRange(INVALID, 0, contentSize-1);
+
   return ByteRange(RESOLVED_PARTIAL_CONTENT, resolved_first, resolved_last);
 }
 

--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -62,4 +62,18 @@ ByteRange ByteRange::parse(std::string rangeStr)
   return byteRange;
 }
 
+ByteRange ByteRange::resolve(int64_t contentSize) const
+{
+  if ( kind() == NONE )
+    return ByteRange(RESOLVED_FULL_CONTENT, 0, contentSize-1);
+
+  const int64_t resolved_first = first() < 0
+                               ? std::max(int64_t(0), contentSize + first())
+                               : first();
+
+  const int64_t resolved_last = std::min(contentSize-1, last());
+
+  return ByteRange(RESOLVED_PARTIAL_CONTENT, resolved_first, resolved_last);
+}
+
 } // namespace kiwix

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -22,6 +22,7 @@
 #define KIWIXLIB_SERVER_BYTE_RANGE_H
 
 #include <cstdint>
+#include <string>
 
 namespace kiwix {
 
@@ -50,6 +51,8 @@ class ByteRange
     int64_t first() const { return first_; }
     int64_t last() const { return last_; }
     int64_t length() const { return last_ + 1 - first_; }
+
+    static ByteRange parse(std::string rangeStr);
 
   private: // data
     Kind kind_;

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -29,7 +29,6 @@ namespace kiwix {
 class ByteRange
 {
   public: // types
-
     // ByteRange is parsed in a request, then it must be resolved (taking
     // into account the actual size of the requested resource) before
     // being applied in the response.

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -21,6 +21,8 @@
 #ifndef KIWIXLIB_SERVER_BYTE_RANGE_H
 #define KIWIXLIB_SERVER_BYTE_RANGE_H
 
+#include <cstdint>
+
 namespace kiwix {
 
 class ByteRange
@@ -41,13 +43,8 @@ class ByteRange
     };
 
   public: // functions
-    ByteRange() : kind_(NONE), first_(0), last_(-1) {}
-
-    ByteRange(Kind kind, int64_t first, int64_t last)
-      : kind_(kind)
-      , first_(first)
-      , last_(last)
-    {}
+    ByteRange();
+    ByteRange(Kind kind, int64_t first, int64_t last);
 
     Kind kind() const { return kind_; }
     int64_t first() const { return first_; }

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -31,6 +31,7 @@ class ByteRange
 
     int64_t first() const { return first_; }
     int64_t last() const { return last_; }
+    int64_t length() const { return last_ + 1 - first_; }
 
   private: // data
     int64_t first_;

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -25,15 +25,37 @@ namespace kiwix {
 
 class ByteRange
 {
-  public: // functions
-    ByteRange() : ByteRange(0, -1) {}
-    ByteRange(int64_t first, int64_t last) : first_(first), last_(last) {}
+  public: // types
+    enum Kind {
+      // No byte-range was present in the request
+      NONE,
 
+      // This byte-range has been parsed from request
+      PARSED,
+
+      // This is a response to a regular request
+      RESOLVED_FULL_CONTENT,
+
+      // This is a response to a range request
+      RESOLVED_PARTIAL_CONTENT
+    };
+
+  public: // functions
+    ByteRange() : kind_(NONE), first_(0), last_(-1) {}
+
+    ByteRange(Kind kind, int64_t first, int64_t last)
+      : kind_(kind)
+      , first_(first)
+      , last_(last)
+    {}
+
+    Kind kind() const { return kind_; }
     int64_t first() const { return first_; }
     int64_t last() const { return last_; }
     int64_t length() const { return last_ + 1 - first_; }
 
   private: // data
+    Kind kind_;
     int64_t first_;
     int64_t last_;
 };

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -29,33 +29,49 @@ namespace kiwix {
 class ByteRange
 {
   public: // types
+
+    // ByteRange is parsed in a request, then it must be resolved (taking
+    // into account the actual size of the requested resource) before
+    // being applied in the response.
+    // The Kind enum represents possible states in such a lifecycle.
     enum Kind {
-      // No byte-range was present in the request
+      // The request is not a range request (no Range header)
       NONE,
 
-      // The value of the Range header is not a valid continuous range.
-      // Note that a valid (according to RFC7233) sequence of byte ranges is
-      // considered invalid in this context.
+      // The value of the Range header is not a valid continuous
+      // range. Note that a valid (according to RFC7233) sequence of multiple
+      // byte ranges is considered invalid in the current implementation
+      // (i.e. only single-range partial requests are supported).
       INVALID,
 
-      // This byte-range has been parsed from request
+      // This byte-range has been successfully parsed from the request
       PARSED,
 
-      // This is a response to a regular request
+      // This is a response to a regular (non-range) request
       RESOLVED_FULL_CONTENT,
 
-      // This is a response to a range request
-      RESOLVED_PARTIAL_CONTENT
+      // The range request is valid but unsatisfiable
+      RESOLVED_UNSATISFIABLE,
+
+      // This is a response to a (satisfiable) range request
+      RESOLVED_PARTIAL_CONTENT,
     };
 
   public: // functions
+    // Constructs a ByteRange object of NONE kind
     ByteRange();
+
+    // Constructs a ByteRange object of the given kind (except NONE)
     ByteRange(Kind kind, int64_t first, int64_t last);
 
+    // Constructs a ByteRange object of PARSED kind corresponding to a
+    // range request of the form "Range: bytes=-suffix_length"
+    explicit ByteRange(int64_t suffix_length);
+
     Kind kind() const { return kind_; }
-    int64_t first() const { return first_; }
-    int64_t last() const { return last_; }
-    int64_t length() const { return last_ + 1 - first_; }
+    int64_t first() const;
+    int64_t last() const;
+    int64_t length() const;
 
     static ByteRange parse(const std::string& rangeStr);
     ByteRange resolve(int64_t contentSize) const;

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+
+#ifndef KIWIXLIB_SERVER_BYTE_RANGE_H
+#define KIWIXLIB_SERVER_BYTE_RANGE_H
+
+namespace kiwix {
+
+class ByteRange
+{
+  public: // functions
+    ByteRange() : ByteRange(0, -1) {}
+    ByteRange(int64_t first, int64_t last) : first_(first), last_(last) {}
+
+    int64_t first() const { return first_; }
+    int64_t last() const { return last_; }
+
+  private: // data
+    int64_t first_;
+    int64_t last_;
+};
+
+} // namespace kiwix
+
+#endif //KIWIXLIB_SERVER_BYTE_RANGE_H

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -49,7 +49,7 @@ class ByteRange
       // This is a response to a regular (non-range) request
       RESOLVED_FULL_CONTENT,
 
-      // The range request is valid but unsatisfiable
+      // The range request is invalid or unsatisfiable
       RESOLVED_UNSATISFIABLE,
 
       // This is a response to a (satisfiable) range request

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -33,6 +33,11 @@ class ByteRange
       // No byte-range was present in the request
       NONE,
 
+      // The value of the Range header is not a valid continuous range.
+      // Note that a valid (according to RFC7233) sequence of byte ranges is
+      // considered invalid in this context.
+      INVALID,
+
       // This byte-range has been parsed from request
       PARSED,
 

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -57,7 +57,7 @@ class ByteRange
     int64_t last() const { return last_; }
     int64_t length() const { return last_ + 1 - first_; }
 
-    static ByteRange parse(std::string rangeStr);
+    static ByteRange parse(const std::string& rangeStr);
     ByteRange resolve(int64_t contentSize) const;
 
   private: // data

--- a/src/server/byte_range.h
+++ b/src/server/byte_range.h
@@ -53,6 +53,7 @@ class ByteRange
     int64_t length() const { return last_ + 1 - first_; }
 
     static ByteRange parse(std::string rangeStr);
+    ByteRange resolve(int64_t contentSize) const;
 
   private: // data
     Kind kind_;

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -86,16 +86,16 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
   } catch (const std::out_of_range&) {}
 
   try {
-    std::string range = get_header(MHD_HTTP_HEADER_RANGE);
-    parse_byte_range(range);
+    range_pair = parse_byte_range(get_header(MHD_HTTP_HEADER_RANGE));
   } catch (const std::out_of_range&) {}
 }
 
 RequestContext::~RequestContext()
 {}
 
-void RequestContext::parse_byte_range(std::string range)
+RequestContext::ByteRange RequestContext::parse_byte_range(std::string range)
 {
+  ByteRange byteRange{0, -1};
   const std::string byteUnitSpec("bytes=");
   if ( kiwix::startsWith(range, byteUnitSpec) ) {
     range.erase(0, byteUnitSpec.size());
@@ -112,10 +112,11 @@ void RequestContext::parse_byte_range(std::string range)
         end = -1;
       }
       if (iss.eof()) {
-        range_pair = std::pair<int, int>(start, end);
+        byteRange = ByteRange(start, end);
       }
     }
   }
+  return byteRange;
 }
 
 
@@ -199,7 +200,7 @@ bool RequestContext::has_range() const {
   return range_pair.first <= range_pair.second;
 }
 
-std::pair<int, int> RequestContext::get_range() const {
+RequestContext::ByteRange RequestContext::get_range() const {
   return range_pair;
 }
 

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <cstdio>
 #include <atomic>
-#include <limits>
 
 namespace kiwix {
 
@@ -61,7 +60,6 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
     return "";
   }
 }
-
 
 } // unnamed namespace
 

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -62,8 +62,6 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
   }
 }
 
-using ByteRange = RequestContext::ByteRange;
-
 ByteRange parse_byte_range(std::string range)
 {
   ByteRange byteRange{0, -1};
@@ -202,7 +200,7 @@ bool RequestContext::has_range() const {
   return byteRange_.first() <= byteRange_.last();
 }
 
-RequestContext::ByteRange RequestContext::get_range() const {
+ByteRange RequestContext::get_range() const {
   return byteRange_;
 }
 

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -86,9 +86,14 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
         (get_header(MHD_HTTP_HEADER_ACCEPT_ENCODING).find("deflate") != std::string::npos);
   } catch (const std::out_of_range&) {}
 
-  /*Check if range is requested. */
   try {
     std::string range = get_header(MHD_HTTP_HEADER_RANGE);
+    parse_byte_range(range);
+  } catch (const std::out_of_range&) {}
+}
+
+void RequestContext::parse_byte_range(std::string range)
+{
     const std::string byteUnitSpec("bytes=");
     if ( kiwix::startsWith(range, byteUnitSpec) ) {
       range.erase(0, byteUnitSpec.size());
@@ -110,7 +115,6 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
         }
       }
     }
-  } catch (const std::out_of_range&) {}
 }
 
 RequestContext::~RequestContext()

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -20,7 +20,6 @@
 
 
 #include "request_context.h"
-#include "tools/stringTools.h"
 #include <string.h>
 #include <stdexcept>
 #include <sstream>
@@ -63,32 +62,6 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
   }
 }
 
-ByteRange parse_byte_range(std::string range)
-{
-  ByteRange byteRange;
-  const std::string byteUnitSpec("bytes=");
-  if ( kiwix::startsWith(range, byteUnitSpec) ) {
-    range.erase(0, byteUnitSpec.size());
-    std::istringstream iss(range);
-
-    int64_t start, end = INT64_MAX;
-    if (iss >> start) {
-      if ( start < 0 ) {
-        if ( iss.eof() )
-          byteRange = ByteRange(ByteRange::PARSED, start, end);
-      } else {
-        char c;
-        if (iss >> c && c=='-') {
-          iss >> end; // if this fails, end is not modified, which is OK
-          if (iss.eof())
-            byteRange = ByteRange(ByteRange::PARSED, start, end);
-        }
-      }
-    }
-  }
-  return byteRange;
-}
-
 
 } // unnamed namespace
 
@@ -114,7 +87,7 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
   } catch (const std::out_of_range&) {}
 
   try {
-    byteRange_ = parse_byte_range(get_header(MHD_HTTP_HEADER_RANGE));
+    byteRange_ = ByteRange::parse(get_header(MHD_HTTP_HEADER_RANGE));
   } catch (const std::out_of_range&) {}
 }
 

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <cstdio>
 #include <atomic>
+#include <limits>
 
 namespace kiwix {
 
@@ -64,6 +65,8 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
 
 ByteRange parse_byte_range(std::string range)
 {
+  const int64_t int64_max = std::numeric_limits<int64_t>::max();
+
   ByteRange byteRange;
   const std::string byteUnitSpec("bytes=");
   if ( kiwix::startsWith(range, byteUnitSpec) ) {
@@ -73,15 +76,21 @@ ByteRange parse_byte_range(std::string range)
     std::istringstream iss(range);
     char c;
 
-    iss >> start >> c;
-    if (iss.good() && c=='-') {
-      iss >> end;
-      if (iss.fail()) {
-        // Something went wrong while extracting
-        end = -1;
-      }
-      if (iss.eof()) {
-        byteRange = ByteRange(ByteRange::PARSED, start, end);
+    iss >> start;
+    if ( start < 0 ) {
+      if ( iss.eof() )
+        byteRange = ByteRange(ByteRange::PARSED, start, int64_max);
+    } else {
+      iss >> c;
+      if (iss.good() && c=='-') {
+        iss >> end;
+        if (iss.fail()) {
+          // Something went wrong while extracting
+          end = -1;
+        }
+        if (iss.eof()) {
+          byteRange = ByteRange(ByteRange::PARSED, start, end);
+        }
       }
     }
   }

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -75,7 +75,6 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
   version(version),
   requestIndex(s_requestIndex++),
   acceptEncodingDeflate(false),
-  accept_range(false),
   range_pair(0, -1)
 {
   MHD_get_connection_values(connection, MHD_HEADER_KIND, &RequestContext::fill_header, this);
@@ -113,7 +112,6 @@ void RequestContext::parse_byte_range(std::string range)
         end = -1;
       }
       if (iss.eof()) {
-        accept_range = true;
         range_pair = std::pair<int, int>(start, end);
       }
     }
@@ -155,7 +153,7 @@ void RequestContext::print_debug_info() const {
   printf("full_url: %s\n", full_url.c_str());
   printf("url   : %s\n", url.c_str());
   printf("acceptEncodingDeflate : %d\n", acceptEncodingDeflate);
-  printf("has_range : %d\n", accept_range);
+  printf("has_range : %d\n", has_range());
   printf("is_valid_url : %d\n", is_valid_url());
   printf(".............\n");
 }
@@ -198,7 +196,7 @@ bool RequestContext::is_valid_url() const {
 }
 
 bool RequestContext::has_range() const {
-  return accept_range;
+  return range_pair.first <= range_pair.second;
 }
 
 std::pair<int, int> RequestContext::get_range() const {

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -126,7 +126,7 @@ void RequestContext::print_debug_info() const {
   printf("full_url: %s\n", full_url.c_str());
   printf("url   : %s\n", url.c_str());
   printf("acceptEncodingDeflate : %d\n", acceptEncodingDeflate);
-  printf("has_range : %d\n", has_range());
+  printf("has_range : %d\n", byteRange_.kind() != ByteRange::NONE);
   printf("is_valid_url : %d\n", is_valid_url());
   printf(".............\n");
 }
@@ -166,10 +166,6 @@ std::string RequestContext::get_full_url() const {
 
 bool RequestContext::is_valid_url() const {
   return !url.empty();
-}
-
-bool RequestContext::has_range() const {
-  return byteRange_.kind() == ByteRange::PARSED;
 }
 
 ByteRange RequestContext::get_range() const {

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -65,31 +65,23 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
 
 ByteRange parse_byte_range(std::string range)
 {
-  const int64_t int64_max = std::numeric_limits<int64_t>::max();
-
   ByteRange byteRange;
   const std::string byteUnitSpec("bytes=");
   if ( kiwix::startsWith(range, byteUnitSpec) ) {
     range.erase(0, byteUnitSpec.size());
-    int start = 0;
-    int end = -1;
     std::istringstream iss(range);
-    char c;
 
-    iss >> start;
-    if ( start < 0 ) {
-      if ( iss.eof() )
-        byteRange = ByteRange(ByteRange::PARSED, start, int64_max);
-    } else {
-      iss >> c;
-      if (iss.good() && c=='-') {
-        iss >> end;
-        if (iss.fail()) {
-          // Something went wrong while extracting
-          end = -1;
-        }
-        if (iss.eof()) {
+    int64_t start, end = INT64_MAX;
+    if (iss >> start) {
+      if ( start < 0 ) {
+        if ( iss.eof() )
           byteRange = ByteRange(ByteRange::PARSED, start, end);
+      } else {
+        char c;
+        if (iss >> c && c=='-') {
+          iss >> end; // if this fails, end is not modified, which is OK
+          if (iss.eof())
+            byteRange = ByteRange(ByteRange::PARSED, start, end);
         }
       }
     }

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -64,7 +64,7 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
 
 ByteRange parse_byte_range(std::string range)
 {
-  ByteRange byteRange{0, -1};
+  ByteRange byteRange;
   const std::string byteUnitSpec("bytes=");
   if ( kiwix::startsWith(range, byteUnitSpec) ) {
     range.erase(0, byteUnitSpec.size());
@@ -81,7 +81,7 @@ ByteRange parse_byte_range(std::string range)
         end = -1;
       }
       if (iss.eof()) {
-        byteRange = ByteRange(start, end);
+        byteRange = ByteRange(ByteRange::PARSED, start, end);
       }
     }
   }
@@ -197,7 +197,7 @@ bool RequestContext::is_valid_url() const {
 }
 
 bool RequestContext::has_range() const {
-  return byteRange_.first() <= byteRange_.last();
+  return byteRange_.kind() == ByteRange::PARSED;
 }
 
 ByteRange RequestContext::get_range() const {

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -62,6 +62,35 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
   }
 }
 
+using ByteRange = RequestContext::ByteRange;
+
+ByteRange parse_byte_range(std::string range)
+{
+  ByteRange byteRange{0, -1};
+  const std::string byteUnitSpec("bytes=");
+  if ( kiwix::startsWith(range, byteUnitSpec) ) {
+    range.erase(0, byteUnitSpec.size());
+    int start = 0;
+    int end = -1;
+    std::istringstream iss(range);
+    char c;
+
+    iss >> start >> c;
+    if (iss.good() && c=='-') {
+      iss >> end;
+      if (iss.fail()) {
+        // Something went wrong while extracting
+        end = -1;
+      }
+      if (iss.eof()) {
+        byteRange = ByteRange(start, end);
+      }
+    }
+  }
+  return byteRange;
+}
+
+
 } // unnamed namespace
 
 RequestContext::RequestContext(struct MHD_Connection* connection,
@@ -92,33 +121,6 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
 
 RequestContext::~RequestContext()
 {}
-
-RequestContext::ByteRange RequestContext::parse_byte_range(std::string range)
-{
-  ByteRange byteRange{0, -1};
-  const std::string byteUnitSpec("bytes=");
-  if ( kiwix::startsWith(range, byteUnitSpec) ) {
-    range.erase(0, byteUnitSpec.size());
-    int start = 0;
-    int end = -1;
-    std::istringstream iss(range);
-    char c;
-
-    iss >> start >> c;
-    if (iss.good() && c=='-') {
-      iss >> end;
-      if (iss.fail()) {
-        // Something went wrong while extracting
-        end = -1;
-      }
-      if (iss.eof()) {
-        byteRange = ByteRange(start, end);
-      }
-    }
-  }
-  return byteRange;
-}
-
 
 int RequestContext::fill_header(void *__this, enum MHD_ValueKind kind,
                                  const char *key, const char *value)

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -104,7 +104,7 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
   version(version),
   requestIndex(s_requestIndex++),
   acceptEncodingDeflate(false),
-  range_pair(0, -1)
+  byteRange_()
 {
   MHD_get_connection_values(connection, MHD_HEADER_KIND, &RequestContext::fill_header, this);
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, &RequestContext::fill_argument, this);
@@ -115,7 +115,7 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
   } catch (const std::out_of_range&) {}
 
   try {
-    range_pair = parse_byte_range(get_header(MHD_HTTP_HEADER_RANGE));
+    byteRange_ = parse_byte_range(get_header(MHD_HTTP_HEADER_RANGE));
   } catch (const std::out_of_range&) {}
 }
 
@@ -199,11 +199,11 @@ bool RequestContext::is_valid_url() const {
 }
 
 bool RequestContext::has_range() const {
-  return range_pair.first <= range_pair.second;
+  return byteRange_.first() <= byteRange_.last();
 }
 
 RequestContext::ByteRange RequestContext::get_range() const {
-  return range_pair;
+  return byteRange_;
 }
 
 template<>

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -92,33 +92,33 @@ RequestContext::RequestContext(struct MHD_Connection* connection,
   } catch (const std::out_of_range&) {}
 }
 
-void RequestContext::parse_byte_range(std::string range)
-{
-    const std::string byteUnitSpec("bytes=");
-    if ( kiwix::startsWith(range, byteUnitSpec) ) {
-      range.erase(0, byteUnitSpec.size());
-      int start = 0;
-      int end = -1;
-      std::istringstream iss(range);
-      char c;
-
-      iss >> start >> c;
-      if (iss.good() && c=='-') {
-        iss >> end;
-        if (iss.fail()) {
-          // Something went wrong will extracting.
-          end = -1;
-        }
-        if (iss.eof()) {
-          accept_range = true;
-          range_pair = std::pair<int, int>(start, end);
-        }
-      }
-    }
-}
-
 RequestContext::~RequestContext()
 {}
+
+void RequestContext::parse_byte_range(std::string range)
+{
+  const std::string byteUnitSpec("bytes=");
+  if ( kiwix::startsWith(range, byteUnitSpec) ) {
+    range.erase(0, byteUnitSpec.size());
+    int start = 0;
+    int end = -1;
+    std::istringstream iss(range);
+    char c;
+
+    iss >> start >> c;
+    if (iss.good() && c=='-') {
+      iss >> end;
+      if (iss.fail()) {
+        // Something went wrong while extracting
+        end = -1;
+      }
+      if (iss.eof()) {
+        accept_range = true;
+        range_pair = std::pair<int, int>(start, end);
+      }
+    }
+  }
+}
 
 
 int RequestContext::fill_header(void *__this, enum MHD_ValueKind kind,

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -27,6 +27,8 @@
 #include <map>
 #include <stdexcept>
 
+#include "byte_range.h"
+
 extern "C" {
 #include <microhttpd.h>
 }
@@ -51,20 +53,6 @@ class IndexError: public std::runtime_error {};
 
 
 class RequestContext {
-  public: // types
-    class ByteRange {
-      public: // functions
-        ByteRange() : ByteRange(0, -1) {}
-        ByteRange(int64_t first, int64_t last) : first_(first), last_(last) {}
-
-        int64_t first() const { return first_; }
-        int64_t last() const { return last_; }
-
-      private: // data
-        int64_t first_;
-        int64_t last_;
-    };
-
   public: // functions
     RequestContext(struct MHD_Connection* connection,
                    std::string rootLocation,

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -86,9 +86,6 @@ class RequestContext {
 
     bool can_compress() const { return acceptEncodingDeflate; }
 
-  private: // functions
-    static ByteRange parse_byte_range(std::string range);
-
   private: // data
     std::string full_url;
     std::string url;

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -80,7 +80,6 @@ class RequestContext {
     std::string get_url_part(int part) const;
     std::string get_full_url() const;
 
-    bool has_range() const;
     ByteRange get_range() const;
 
     bool can_compress() const { return acceptEncodingDeflate; }

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -86,6 +86,9 @@ class RequestContext {
 
     bool can_compress() const { return acceptEncodingDeflate; }
 
+  private: // functions
+    void parse_byte_range(std::string range);
+
   private: // data
     std::string full_url;
     std::string url;

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -98,7 +98,6 @@ class RequestContext {
 
     bool acceptEncodingDeflate;
 
-    bool accept_range;
     ByteRange range_pair;
     std::map<std::string, std::string> headers;
     std::map<std::string, std::string> arguments;

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -87,7 +87,7 @@ class RequestContext {
     bool can_compress() const { return acceptEncodingDeflate; }
 
   private: // functions
-    void parse_byte_range(std::string range);
+    static ByteRange parse_byte_range(std::string range);
 
   private: // data
     std::string full_url;

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -52,7 +52,18 @@ class IndexError: public std::runtime_error {};
 
 class RequestContext {
   public: // types
-  typedef std::pair<int, int> ByteRange;
+    class ByteRange {
+      public: // functions
+        ByteRange() : ByteRange(0, -1) {}
+        ByteRange(int64_t first, int64_t last) : first_(first), last_(last) {}
+
+        int64_t first() const { return first_; }
+        int64_t last() const { return last_; }
+
+      private: // data
+        int64_t first_;
+        int64_t last_;
+    };
 
   public: // functions
     RequestContext(struct MHD_Connection* connection,
@@ -95,7 +106,7 @@ class RequestContext {
 
     bool acceptEncodingDeflate;
 
-    ByteRange range_pair;
+    ByteRange byteRange_;
     std::map<std::string, std::string> headers;
     std::map<std::string, std::string> arguments;
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -41,10 +41,10 @@ bool is_compressible_mime_type(const std::string& mimeType)
 
 int get_range_len(const kiwix::Entry& entry, RequestContext::ByteRange range)
 {
-  const int entrySize = entry.getSize();
-  return range.second == -1
-       ? entrySize - range.first
-       : std::min(range.second + 1, entrySize) - range.first;
+  const int64_t entrySize = entry.getSize();
+  return range.last() == -1
+       ? entrySize - range.first()
+       : std::min(range.last() + 1, entrySize) - range.first();
 }
 
 } // unnamed namespace
@@ -330,7 +330,7 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
     set_compress(true);
   } else {
     const int range_len = get_range_len(entry, request.get_range());
-    set_range_first(request.get_range().first);
+    set_range_first(request.get_range().first());
     set_range_len(range_len);
   }
 }

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -173,7 +173,7 @@ MHD_Response*
 Response::create_error_response(const RequestContext& request) const
 {
   MHD_Response* response = MHD_create_response_from_buffer(0, NULL, MHD_RESPMEM_PERSISTENT);
-  if ( m_returnCode == MHD_HTTP_RANGE_NOT_SATISFIABLE ) {
+  if ( m_returnCode == 416 ) {
     std::ostringstream oss;
     oss << "bytes */" << m_byteRange.length();
 
@@ -343,7 +343,7 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
     set_content(content);
     set_compress(true);
   } else if ( m_byteRange.kind() == ByteRange::INVALID ) {
-    set_code(MHD_HTTP_RANGE_NOT_SATISFIABLE);
+    set_code(416);
     set_content("");
     m_mode = ResponseMode::ERROR;
   }

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -336,7 +336,8 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
   set_cacheable();
 
   m_byteRange = request.get_range().resolve(entry.getSize());
-  if ( m_byteRange.kind() == ByteRange::RESOLVED_FULL_CONTENT && is_compressible_mime_type(mimeType) ) {
+  const bool noRange = m_byteRange.kind() == ByteRange::RESOLVED_FULL_CONTENT;
+  if ( noRange && is_compressible_mime_type(mimeType) ) {
     zim::Blob raw_content = entry.getBlob();
     const std::string content = string(raw_content.data(), raw_content.size());
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -39,7 +39,7 @@ bool is_compressible_mime_type(const std::string& mimeType)
       || mimeType.find("application/json") != string::npos;
 }
 
-int get_range_len(const kiwix::Entry& entry, RequestContext::ByteRange range)
+int get_range_len(const kiwix::Entry& entry, ByteRange range)
 {
   const int64_t entrySize = entry.getSize();
   return range.last() == -1

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -39,21 +39,6 @@ bool is_compressible_mime_type(const std::string& mimeType)
       || mimeType.find("application/json") != string::npos;
 }
 
-ByteRange resolve_byte_range(const kiwix::Entry& entry, ByteRange range)
-{
-  const int64_t entrySize = entry.getSize();
-
-  if ( range.kind() == ByteRange::NONE )
-    return ByteRange(ByteRange::RESOLVED_FULL_CONTENT, 0, entrySize-1);
-
-  const int64_t resolved_first = range.first() < 0
-                               ? std::max(int64_t(0), entrySize + range.first())
-                               : range.first();
-
-  const int64_t resolved_last = std::min(entrySize-1, range.last());
-
-  return ByteRange(ByteRange::RESOLVED_PARTIAL_CONTENT, resolved_first, resolved_last);
-}
 
 } // unnamed namespace
 
@@ -338,7 +323,7 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
     set_content(content);
     set_compress(true);
   } else {
-    m_byteRange = resolve_byte_range(entry, request.get_range());
+    m_byteRange = request.get_range().resolve(entry.getSize());
   }
 }
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -273,7 +273,7 @@ MHD_Response*
 Response::create_mhd_response(const RequestContext& request)
 {
   switch (m_mode) {
-    case ResponseMode::ERROR:
+    case ResponseMode::ERROR_RESPONSE:
       return create_error_response(request);
 
     case ResponseMode::RAW_CONTENT :
@@ -292,7 +292,7 @@ int Response::send(const RequestContext& request, MHD_Connection* connection)
 {
   MHD_Response* response = create_mhd_response(request);
 
-  if ( m_mode != ResponseMode::ERROR ) {
+  if ( m_mode != ResponseMode::ERROR_RESPONSE ) {
     MHD_add_response_header(response, "Access-Control-Allow-Origin", "*");
     MHD_add_response_header(response, MHD_HTTP_HEADER_CACHE_CONTROL,
       m_etag.get_option(ETag::CACHEABLE_ENTITY) ? "max-age=2723040, public" : "no-cache, no-store, must-revalidate");
@@ -345,7 +345,7 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
   } else if ( m_byteRange.kind() == ByteRange::INVALID ) {
     set_code(416);
     set_content("");
-    m_mode = ResponseMode::ERROR;
+    m_mode = ResponseMode::ERROR_RESPONSE;
   }
 }
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -342,7 +342,7 @@ void Response::set_entry(const Entry& entry, const RequestContext& request) {
 
     set_content(content);
     set_compress(true);
-  } else if ( m_byteRange.kind() == ByteRange::INVALID ) {
+  } else if ( m_byteRange.kind() == ByteRange::RESOLVED_UNSATISFIABLE ) {
     set_code(416);
     set_content("");
     m_mode = ResponseMode::ERROR_RESPONSE;

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -241,7 +241,7 @@ Response::create_redirection_mhd_response() const
 MHD_Response*
 Response::create_entry_mhd_response() const
 {
-  MHD_Response* response = MHD_create_response_from_callback(m_entry.getSize(),
+  MHD_Response* response = MHD_create_response_from_callback(m_lenRange,
                                                16384,
                                                callback_reader_from_entry,
                                                new RunningResponse(m_entry, m_startRange),

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -50,9 +50,7 @@ ByteRange resolve_byte_range(const kiwix::Entry& entry, ByteRange range)
                                ? std::max(int64_t(0), entrySize + range.first())
                                : range.first();
 
-  const int64_t resolved_last = range.last() < 0
-                              ? entrySize - 1
-                              : std::min(entrySize-1, range.last());
+  const int64_t resolved_last = std::min(entrySize-1, range.last());
 
   return ByteRange(ByteRange::RESOLVED_PARTIAL_CONTENT, resolved_first, resolved_last);
 }

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -46,10 +46,15 @@ ByteRange resolve_byte_range(const kiwix::Entry& entry, ByteRange range)
   if ( range.kind() == ByteRange::NONE )
     return ByteRange(ByteRange::RESOLVED_FULL_CONTENT, 0, entrySize-1);
 
+  const int64_t resolved_first = range.first() < 0
+                               ? std::max(int64_t(0), entrySize + range.first())
+                               : range.first();
+
   const int64_t resolved_last = range.last() < 0
                               ? entrySize - 1
                               : std::min(entrySize-1, range.last());
-  return ByteRange(ByteRange::RESOLVED_PARTIAL_CONTENT, range.first(), resolved_last);
+
+  return ByteRange(ByteRange::RESOLVED_PARTIAL_CONTENT, resolved_first, resolved_last);
 }
 
 } // unnamed namespace

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -43,7 +43,7 @@ int get_range_len(const kiwix::Entry& entry, RequestContext::ByteRange range)
 {
   return range.second == -1
        ? entry.getSize() - range.first
-       : range.second - range.first;
+       : range.second - range.first + 1;
 }
 
 } // unnamed namespace

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -41,9 +41,10 @@ bool is_compressible_mime_type(const std::string& mimeType)
 
 int get_range_len(const kiwix::Entry& entry, RequestContext::ByteRange range)
 {
+  const int entrySize = entry.getSize();
   return range.second == -1
-       ? entry.getSize() - range.first
-       : range.second - range.first + 1;
+       ? entrySize - range.first
+       : std::min(range.second + 1, entrySize) - range.first;
 }
 
 } // unnamed namespace

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -241,12 +241,14 @@ Response::create_entry_mhd_response() const
   MHD_add_response_header(response,
     MHD_HTTP_HEADER_CONTENT_TYPE, m_mimeType.c_str());
   MHD_add_response_header(response, MHD_HTTP_HEADER_ACCEPT_RANGES, "bytes");
-  std::ostringstream oss;
-  oss << "bytes " << m_byteRange.first() << "-" << m_byteRange.last()
-      << "/" << m_entry.getSize();
+  if ( m_byteRange.kind() == ByteRange::RESOLVED_PARTIAL_CONTENT ) {
+    std::ostringstream oss;
+    oss << "bytes " << m_byteRange.first() << "-" << m_byteRange.last()
+        << "/" << m_entry.getSize();
 
-  MHD_add_response_header(response,
-    MHD_HTTP_HEADER_CONTENT_RANGE, oss.str().c_str());
+    MHD_add_response_header(response,
+      MHD_HTTP_HEADER_CONTENT_RANGE, oss.str().c_str());
+  }
 
   MHD_add_response_header(response,
     MHD_HTTP_HEADER_CONTENT_LENGTH, kiwix::to_string(content_length).c_str());

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include <mustache.hpp>
+#include "byte_range.h"
 #include "entry.h"
 #include "etag.h"
 
@@ -61,8 +62,6 @@ class Response {
     void set_etag(const ETag& etag) { m_etag = etag; }
     void set_compress(bool compress) { m_compress = compress; }
     void set_taskbar(const std::string& bookName, const std::string& bookTitle);
-    void set_range_first(uint64_t start) { m_startRange = start; }
-    void set_range_len(uint64_t len) { m_lenRange = len; }
 
     int getReturnCode() const { return m_returnCode; }
     std::string get_mimeType() const { return m_mimeType; }
@@ -93,8 +92,7 @@ class Response {
     bool m_addTaskbar;
     std::string m_bookName;
     std::string m_bookTitle;
-    uint64_t m_startRange;
-    uint64_t m_lenRange;
+    ByteRange m_byteRange;
     ETag m_etag;
 };
 

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -35,7 +35,7 @@ extern "C" {
 namespace kiwix {
 
 enum class ResponseMode {
-  ERROR,
+  ERROR_RESPONSE,
   RAW_CONTENT,
   REDIRECTION,
   ENTRY

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -35,6 +35,7 @@ extern "C" {
 namespace kiwix {
 
 enum class ResponseMode {
+  ERROR,
   RAW_CONTENT,
   REDIRECTION,
   ENTRY
@@ -73,6 +74,7 @@ class Response {
 
   private: // functions
     MHD_Response* create_mhd_response(const RequestContext& request);
+    MHD_Response* create_error_response(const RequestContext& request) const;
     MHD_Response* create_raw_content_mhd_response(const RequestContext& request);
     MHD_Response* create_redirection_mhd_response() const;
     MHD_Response* create_entry_mhd_response() const;

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -465,7 +465,9 @@ TEST_F(ServerTest, InvalidAndMultiRangeByteRangeRequestsResultIn416Responses)
 
   const char* invalidRanges[] = {
     "0-10", "bytes=", "bytes=123", "bytes=-10-20", "bytes=10-20xxx",
-    "bytes=10-0", "bytes=10-20, 30-40"
+    "bytes=10-0", // reversed range
+    "bytes=10-20, 30-40", // multi-range
+    "bytes=1000000-", "bytes=30000-30100" // unsatisfiable ranges
   };
 
   for( const char* range : invalidRanges )

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -479,3 +479,18 @@ TEST_F(ServerTest, InvalidAndMultiRangeByteRangeRequestsResultIn416Responses)
     EXPECT_EQ("bytes */20077", p->get_header_value("Content-Range")) << ctx;
   }
 }
+
+TEST_F(ServerTest, RangeHasPrecedenceOverCompression)
+{
+  const char url[] = "/zimfile/I/m/Ray_Charles_classic_piano_pose.jpg";
+
+  const Headers onlyRange{ {"Range", "bytes=123-456"} };
+  Headers rangeAndCompression(onlyRange);
+  rangeAndCompression.insert({"Accept-Encoding", "deflate"});
+
+  const auto p1 = zfs1_->GET(url, onlyRange);
+  const auto p2 = zfs1_->GET(url, rangeAndCompression);
+  EXPECT_EQ(p1->status, p2->status);
+  EXPECT_EQ(invariantHeaders(p1->headers), invariantHeaders(p2->headers));
+  EXPECT_EQ(p1->body, p2->body);
+}

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -436,4 +436,18 @@ TEST_F(ServerTest, ValidSingleRangeByteRangeRequestsAreHandledProperly)
     EXPECT_EQ(334, p->body.size());
     EXPECT_EQ(full->body.substr(123, 334), p->body);
   }
+
+  {
+    const auto p = zfs1_->GET(url, { {"Range", "bytes=20000-"} } );
+    EXPECT_EQ(206, p->status);
+    EXPECT_EQ(full->body.substr(20000), p->body);
+    EXPECT_EQ("bytes 20000-20076/20077", p->get_header_value("Content-Range"));
+  }
+
+  {
+    const auto p = zfs1_->GET(url, { {"Range", "bytes=-100"} } );
+    EXPECT_EQ(206, p->status);
+    EXPECT_EQ(full->body.substr(19977), p->body);
+    EXPECT_EQ("bytes 19977-20076/20077", p->get_header_value("Content-Range"));
+  }
 }

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -413,12 +413,15 @@ TEST_F(ServerTest, ValidSingleRangeByteRangeRequestsAreHandledProperly)
 {
   const char url[] = "/zimfile/I/m/Ray_Charles_classic_piano_pose.jpg";
   const auto full = zfs1_->GET(url);
+  EXPECT_FALSE(full->has_header("Content-Range"));
+  EXPECT_EQ("bytes", full->get_header_value("Accept-Ranges"));
 
   {
     const auto p = zfs1_->GET(url, { {"Range", "bytes=0-100000"} } );
     EXPECT_EQ(206, p->status);
     EXPECT_EQ(full->body, p->body);
     EXPECT_EQ("bytes 0-20076/20077", p->get_header_value("Content-Range"));
+    EXPECT_EQ("bytes", p->get_header_value("Accept-Ranges"));
   }
 
   {
@@ -427,6 +430,7 @@ TEST_F(ServerTest, ValidSingleRangeByteRangeRequestsAreHandledProperly)
     EXPECT_EQ("bytes 0-10/20077", p->get_header_value("Content-Range"));
     EXPECT_EQ(11, p->body.size());
     EXPECT_EQ(full->body.substr(0, 11), p->body);
+    EXPECT_EQ("bytes", p->get_header_value("Accept-Ranges"));
   }
 
   {
@@ -435,6 +439,7 @@ TEST_F(ServerTest, ValidSingleRangeByteRangeRequestsAreHandledProperly)
     EXPECT_EQ("bytes 123-456/20077", p->get_header_value("Content-Range"));
     EXPECT_EQ(334, p->body.size());
     EXPECT_EQ(full->body.substr(123, 334), p->body);
+    EXPECT_EQ("bytes", p->get_header_value("Accept-Ranges"));
   }
 
   {
@@ -442,6 +447,7 @@ TEST_F(ServerTest, ValidSingleRangeByteRangeRequestsAreHandledProperly)
     EXPECT_EQ(206, p->status);
     EXPECT_EQ(full->body.substr(20000), p->body);
     EXPECT_EQ("bytes 20000-20076/20077", p->get_header_value("Content-Range"));
+    EXPECT_EQ("bytes", p->get_header_value("Accept-Ranges"));
   }
 
   {
@@ -449,5 +455,6 @@ TEST_F(ServerTest, ValidSingleRangeByteRangeRequestsAreHandledProperly)
     EXPECT_EQ(206, p->status);
     EXPECT_EQ(full->body.substr(19977), p->body);
     EXPECT_EQ("bytes 19977-20076/20077", p->get_header_value("Content-Range"));
+    EXPECT_EQ("bytes", p->get_header_value("Accept-Ranges"));
   }
 }


### PR DESCRIPTION
Will close kiwix/kiwix-tools#148

This PR enables handling of partial content requests with a single byte-range. Requests for two or more byte ranges (even if they effectively constitute a single continuous range) are rejected with a 416 (Range Not Satisfiable) error response. Such behaviour complies with somewhat liberal interpretation of the [spec](https://tools.ietf.org/html/rfc7233#section-4.4)):

> The 416 (Range Not Satisfiable) status code indicates that none of the ranges in the request's Range header field (Section 3.1) overlap the current extent of the selected resource or that the set of ranges requested has been rejected due to invalid ranges or **an excessive request** of small or overlapping ranges.

Support for [`If-Range`](https://tools.ietf.org/html/rfc7233#section-3.2) conditional requests is not implemented.

Partial requests work only for content (entries) from the served ZIM file(s). If both `Range:` and `Accept-Encoding: deflate` headers are present in the request, the former has precedence and uncompressed partial content is sent in a 206 response (even if a 200 response to a respective non-range request would have its content compressed).

The changes have been validated with new test cases in the server unit-test (as well as some manual experiments with kiwix-serve and curl).

This PR should be easy to review in its final state though some issues with the state of the current code in master are more obvious when looking at the first several commits in the PR history. I didn't spend any time cleaning up the development history, since I believe that this PR can be merged as a single squashed commit.