### PR TITLE
Fix for the failing assertion in the ByteRange constructor

### DIFF
--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -65,7 +65,7 @@ ByteRange::ByteRange(Kind kind, int64_t first, int64_t last)
 {
   assert(kind != NONE);
   assert(first >= 0);
-  assert(last >= first);
+  assert(last >= first || (first == 0 && last == -1));
 }
 
 ByteRange::ByteRange(int64_t suffix_length)


### PR DESCRIPTION
Will close #363 .

The assertion in the `ByteRange` constructor was written under the assumption that the content must have non-zero size. Now it allows that corner case. The rest of the `ByteRange` code should handle that case normally (the only arguable scenario being that a 416 (Not Satisfiable) response is sent to any range request of such a 0-sized resource).