### PR TITLE
Fix missing byte_range.h include

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -1,6 +1,6 @@
 
 
-
+#include "byte_range.h"
 #include "response.h"
 #include "request_context.h"
 #include "kiwixlib-resources.h"


### PR DESCRIPTION
Fixes the following build failure I was running into on 9.2.2/Debian unstable:

```
[2/19] c++ -Isrc/25a6634@@kiwix@sha -Isrc -I../src -Iinclude -I../include -Istatic -I/usr/include/x86_64-linux-gnu -I/usr/include/p11-kit-1 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++11 -g -fPIC -pthread -MD -MQ 'src/25a6634@@kiwix@sha/server_response.cpp.o' -MF 'src/25a6634@@kiwix@sha/server_response.cpp.o.d' -o 'src/25a6634@@kiwix@sha/server_response.cpp.o' -c ../src/server/response.cpp
FAILED: src/25a6634@@kiwix@sha/server_response.cpp.o 
c++ -Isrc/25a6634@@kiwix@sha -Isrc -I../src -Iinclude -I../include -Istatic -I/usr/include/x86_64-linux-gnu -I/usr/include/p11-kit-1 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++11 -g -fPIC -pthread -MD -MQ 'src/25a6634@@kiwix@sha/server_response.cpp.o' -MF 'src/25a6634@@kiwix@sha/server_response.cpp.o.d' -o 'src/25a6634@@kiwix@sha/server_response.cpp.o' -c ../src/server/response.cpp
In file included from ../src/server/response.cpp:4:
../src/server/response.h:96:5: error: 'ByteRange' does not name a type
   96 |     ByteRange m_byteRange;
      |     ^~~~~~~~~
../src/server/response.cpp: In member function 'MHD_Response* kiwix::Response::create_error_response(const kiwix::RequestContext&) const':
../src/server/response.cpp:178:26: error: 'm_byteRange' was not declared in this scope; did you mean 'ByteRange'?
  178 |     oss << "bytes */" << m_byteRange.length();
      |                          ^~~~~~~~~~~
      |                          ByteRange
../src/server/response.cpp: In member function 'MHD_Response* kiwix::Response::create_entry_mhd_response() const':
../src/server/response.cpp:249:31: error: 'm_byteRange' was not declared in this scope; did you mean 'ByteRange'?
  249 |   const auto content_length = m_byteRange.length();
      |                               ^~~~~~~~~~~
      |                               ByteRange
../src/server/response.cpp: In member function 'int kiwix::Response::send(const kiwix::RequestContext&, MHD_Connection*)':
../src/server/response.cpp:304:38: error: 'm_byteRange' was not declared in this scope; did you mean 'ByteRange'?
  304 |   if (m_returnCode == MHD_HTTP_OK && m_byteRange.kind() == ByteRange::RESOLVED_PARTIAL_CONTENT)
      |                                      ^~~~~~~~~~~
      |                                      ByteRange
../src/server/response.cpp: In member function 'void kiwix::Response::set_entry(const kiwix::Entry&, const kiwix::RequestContext&)':
../src/server/response.cpp:338:3: error: 'm_byteRange' was not declared in this scope; did you mean 'ByteRange'?
  338 |   m_byteRange = request.get_range().resolve(entry.getSize());
      |   ^~~~~~~~~~~
      |   ByteRange
```