### PR TITLE
Pass -latomic for architectures that need it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,11 @@ if 'java' in wrapper
   add_languages('java')
 endif
 
+# See https://github.com/kiwix/kiwix-lib/issues/371
+if target_machine.cpu_family() in ['arm', 'mips', 'm68k', 'ppc']
+  extra_libs += '-latomic'
+endif
+
 thread_dep = dependency('threads')
 libicu_dep = dependency('icu-i18n', static:static_deps)
 libzim_dep = dependency('libzim', version : '>=6.1.1', static:static_deps)

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,6 +53,7 @@ kiwixlib = library('kiwix',
                    kiwix_sources,
                    include_directories : inc,
                    dependencies : all_deps,
+                   link_args: extra_libs,
                    version: meson.project_version(),
                    install: true,
                    install_dir: install_dir)


### PR DESCRIPTION
Some architectures, specifically armel, mipsel, m68k & powerpc in
Debian, need to explicitly link to atomic.

Use meson to see if the target's CPU family is one of those, and if so,
pass -latomic to the linker.

Tested on armel and mipsel machines to verify passing -latomic works, and
on armhf and amd64 to ensure normal builds aren't broken.

Fixes #371.