### PR TITLE
Do not include `kiwix_config.h` in public header.

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -31,7 +31,6 @@
 #include <vector>
 #include "tools/pathTools.h"
 #include "tools/stringTools.h"
-#include "kiwix_config.h"
 
 using namespace std;
 


### PR DESCRIPTION
This define `VERSION` and may conflict with dependent projects.

If some want to get the version of kiwix-lib they can include
`kiwix_config.h` directly.