### PR TITLE
Pass -latomic on sh4 architecture too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ if 'java' in wrapper
 endif
 
 # See https://github.com/kiwix/kiwix-lib/issues/371
-if target_machine.cpu_family() in ['arm', 'mips', 'm68k', 'ppc']
+if target_machine.cpu_family() in ['arm', 'mips', 'm68k', 'ppc', 'sh4']
   extra_libs += '-latomic'
 endif
 


### PR DESCRIPTION
Same as #372.

I originally missed this because meson didn't know about sh4 until
recently (c.f. https://github.com/mesonbuild/meson/pull/7359), but
this should work fine on older meson versions too.