### PR TITLE
Request header case is ignored

### DIFF
--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -26,6 +26,8 @@
 #include <cstdio>
 #include <atomic>
 
+#include "tools/stringTools.h"
+
 namespace kiwix {
 
 static std::atomic_ullong s_requestIndex(0);
@@ -96,7 +98,7 @@ MHD_Result RequestContext::fill_header(void *__this, enum MHD_ValueKind kind,
                                        const char *key, const char *value)
 {
   RequestContext *_this = static_cast<RequestContext*>(__this);
-  _this->headers[key] = value;
+  _this->headers[lcAll(key)] = value;
   return MHD_YES;
 }
 
@@ -178,7 +180,7 @@ std::string RequestContext::get_argument(const std::string& name) const {
 }
 
 std::string RequestContext::get_header(const std::string& name) const {
-  return headers.at(name);
+  return headers.at(lcAll(name));
 }
 
 }

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -523,3 +523,17 @@ TEST_F(ServerTest, RangeHasPrecedenceOverCompression)
   EXPECT_EQ(invariantHeaders(p1->headers), invariantHeaders(p2->headers));
   EXPECT_EQ(p1->body, p2->body);
 }
+
+TEST_F(ServerTest, RangeHeaderIsCaseInsensitive)
+{
+  const char url[] = "/zimfile/I/m/Ray_Charles_classic_piano_pose.jpg";
+  const auto r0 = zfs1_->GET(url, { {"Range", "bytes=100-200"} } );
+
+  const char* header_variations[] = { "RANGE", "range", "rAnGe", "RaNgE" };
+  for ( const char* header : header_variations ) {
+    const auto r = zfs1_->GET(url, { {header, "bytes=100-200"} } );
+    EXPECT_EQ(206, r->status);
+    EXPECT_EQ("bytes 100-200/20077", r->get_header_value("Content-Range"));
+    EXPECT_EQ(r0->body, r->body);
+  }
+}


### PR DESCRIPTION
Fixes #387 

Originally reported against case sensitivity of the `Range` header, this fix applies to all request headers (since according to RFC 7230 all header fields are case-insensitive, see https://tools.ietf.org/html/rfc7230#section-3.2). However, a corresponding unit-test was added only for the Range header.