### PR TITLE
added 204 code for empty return of search.

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -740,6 +740,13 @@ Response InternalServer::handle_search(const RequestContext& request)
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
   }
+
+  //changing status code if no result obtained
+  if(searcher.getEstimatedResultCount() == 0)
+  {
+    response.set_code(MHD_HTTP_NO_CONTENT);
+  }
+
   return response;
 }
 

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -155,7 +155,7 @@ const ResourceCollection resources200Compressible{
   { NO_ETAG,   "/catalog/searchdescription.xml" },
   { NO_ETAG,   "/catalog/search" },
 
-  { NO_ETAG,   "/search?content=zimfile&pattern=abcd" },
+  { NO_ETAG,   "/search?content=zimfile&pattern=a" },
 
   { NO_ETAG,   "/suggest?content=zimfile&term=ray" },
 
@@ -195,6 +195,15 @@ TEST_F(ServerTest, 200)
 {
   for ( const Resource& res : all200Resources() )
     EXPECT_EQ(200, zfs1_->GET(res.url)->status) << "res.url: " << res.url;
+}
+
+// seperate test for 204 code
+
+TEST_F(ServerTest, EmptySearchReturnsA204StatusCode)
+{
+  const char* url="/search?content=zimfile&pattern=abcd";
+  auto res=zfs1_->GET(url);
+  EXPECT_EQ(204, res->status) << "res.url: " << url;
 }
 
 TEST_F(ServerTest, CompressibleContentIsCompressedIfAcceptable)


### PR DESCRIPTION
added status code 204 for empty search return in src/server.cpp as asked in issue #393 ....... I would like to suggest that some changes are also required in test/service.cpp as when empty search is returned, earlier response code was 200 but this time it might show 204 at its place causing fail in some tests.