### PR TITLE
Set fixed size for favicon in home page listing

### DIFF
--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -29,7 +29,7 @@
                 box-shadow: 2px 2px 5px 0px #ccc;
         }
         .book:hover { background-color: #F9F9F9; box-shadow: none;}
-        .book__background { background-repeat: no-repeat; background-size: auto; background-position: top right; }
+        .book__background { background-repeat: no-repeat; background-size: 48px 48px; background-position: top right; }
         .book__title {
                 padding: 0 55px 0 0;overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
                 font-size: 18px; color: #0645ad; line-height: 1em;


### PR DESCRIPTION
While [spec](https://wiki.openzim.org/wiki/Metadata#Favicon) says that the favicon
should be a 48x48 image, ZIM creators might not respect it.

If a ZIM contains a larger favicon, the UI is broken. This fixes it and ensures all favicon have equal sizes, removing the unpleasing lack of harmony that we can see sometimes.

Note that ZIM with smaller size favicon would get blurry as those would be upscaled.