### PR TITLE
Added comment marking dependency of a JS variable with warc2zim

### DIFF
--- a/static/skin/block_external.js
+++ b/static/skin/block_external.js
@@ -1,3 +1,4 @@
+// `block_path` variable used by openzim/warc2zim to detect whether URL blocking is enabled or not
 var block_path = "/catch/external";
 // called only on external links
 function capture_event(e, target) { target.setAttribute("href", encodeURI(block_path + "?source=" + target.href)); }


### PR DESCRIPTION
warc2zim's service worker captures all requests and then decides what to do based on availability of the URL in the ZIM or not.
To allow the external URL blocking mechanism, it needs to known whether this was enabled or not (as those in-iframe links won't be caught).
It detects this by looking for the `window.block_path` variable that is set in the `block_external.js` script.

As this is fragile, we're adding a comment so that a future maintainer knows that a third party tools relies on it.

ping @ikreymer