### PR TITLE
Move aria2 from a build dependency to runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ libraries need to be available:
 * [ICU](https://site.icu-project.org/) (package `libicu-dev` on Ubuntu)
 * [ZIM](https://openzim.org/) (package `libzim-dev` on Ubuntu)
 * [Pugixml](https://pugixml.org/) (package `libpugixml-dev` on Ubuntu)
-* [Aria2](https://aria2.github.io/) (package `aria2` on Ubuntu)
 * [Mustache](https://github.com/kainjow/Mustache) (Just copy the
 header `mustache.hpp` somewhere it can be found by the compiler and/or
 set CPPFLAGS with correct `-I` option). Use Mustache version 3 only.
+
+The following dependency needs to be available at runtime:
+* [Aria2](https://aria2.github.io/) (package `aria2` on Ubuntu)
 
 These dependencies may or may not be packaged by your operating
 system. They may also be packaged but only in an older version. The

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Package: libkiwix-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: libkiwix9 (= ${binary:Version}), ${misc:Depends}, python3, aria2,
+Depends: libkiwix9 (= ${binary:Version}), ${misc:Depends}, python3,
  libzim-dev (>= 6.0.0),
  libicu-dev,
  libpugixml-dev,
@@ -37,7 +37,7 @@ Description: library of common code for Kiwix (development)
 Package: libkiwix9
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, aria2
 Conflicts: libkiwix0, libkiwix3
 Description: library of common code for Kiwix
  Kiwix is an offline Wikipedia reader. libkiwix provides the


### PR DESCRIPTION
Per IRC discussion with @kelson42 and https://github.com/kiwix/kiwix-desktop/issues/505