### PR TITLE
Prevent taskbar and blocker at article level

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -963,7 +963,7 @@ Response InternalServer::handle_content(const RequestContext& request)
     printf("mimeType: %s\n", response.get_mimeType().c_str());
   }
 
-  if (response.get_mimeType().find("text/html") != string::npos)
+  if ( startsWith(response.get_mimeType(), "text/html") )
     response.set_taskbar(bookName, reader->getTitle());
 
   return response;

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -71,6 +71,7 @@ class Response {
     void inject_externallinks_blocker();
 
     bool can_compress(const RequestContext& request) const;
+    bool contentDecorationAllowed() const;
 
   private: // functions
     MHD_Response* create_mhd_response(const RequestContext& request);


### PR DESCRIPTION
Some HTML articles are meant to be displayed through a viewer. In this case,
we know we don't want the server to inject the taskbar nor the link blocker
because the content is not a user-ready web page but a partial element of it.

Such articles still need to be `text/html` to be parsed properly by browsers.

This changes the way we decide to display the tasbar or not.
Previously, we were adding it to every article with a MIME __starting with__ `text/html`.
Now, we're additionally preventing it on `text/html` MIME if there is a `;raw=true` string inside.

This leaves articles with MIME `text/html;raw=true` (warc2zim convention) outside
of the taskbar target.

For similar reasons, the external-link blocker is set to apply to the same set of articles.
Previously, it was applied to all articles which was an (unoticable) mistake.