### PR TITLE
Fix taskbar impl

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -138,9 +138,10 @@ unsigned int Reader::getArticleCount() const
   if (counterMap.empty()) {
     counter = this->nsACount;
   } else {
-    auto it = counterMap.find("text/html");
-    if (it != counterMap.end()) {
-      counter = it->second;
+    for(auto &pair:counterMap) {
+      if (startsWith(pair.first, "text/html")) {
+        counter += pair.second;
+      }
     }
   }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -477,7 +477,6 @@ Response InternalServer::build_homepage(const RequestContext& request)
   response.set_template(RESOURCE::templates::index_html, homepage_data());
   response.set_mimeType("text/html; charset=utf-8");
   response.set_compress(true);
-  response.set_taskbar("", "");
   return response;
 }
 
@@ -795,7 +794,6 @@ Response InternalServer::handle_captured_external(const RequestContext& request)
   response.set_template(RESOURCE::templates::captured_external_html, data);
   response.set_mimeType("text/html; charset=utf-8");
   response.set_compress(true);
-  response.set_taskbar("", "");
   return response;
 }
 
@@ -957,14 +955,13 @@ Response InternalServer::handle_content(const RequestContext& request)
   auto response = get_default_response();
 
   response.set_entry(entry, request);
+  response.set_taskbar(bookName, reader->getTitle());
 
   if (m_verbose.load()) {
     printf("Found %s\n", entry.getPath().c_str());
     printf("mimeType: %s\n", response.get_mimeType().c_str());
   }
 
-  if ( startsWith(response.get_mimeType(), "text/html") )
-    response.set_taskbar(bookName, reader->getTitle());
 
   return response;
 }

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -92,7 +92,6 @@ class Response {
     bool m_withLibraryButton;
     bool m_blockExternalLinks;
     bool m_compress;
-    bool m_addTaskbar;
     std::string m_bookName;
     std::string m_bookTitle;
     ByteRange m_byteRange;


### PR DESCRIPTION
This PR fix few things I remark on #403.

Note that the `getArticleCount` implementation was to assume (and still assume) that article are entries with the mimetype "text/html".
So the assumption made on the new libzim api to assume that suggestion and random should be based on
mimetype is coherent (but maybe still a wrong idea).
It worth noting also that the current implementation of libzim_next [`getRandomArticle`](https://github.com/kiwix/kiwix-lib/blob/libzim_next/src/reader.cpp#L168-L187) (not merged) is broken as it only test if mimetype is equal to "text/html".