### PR TITLE
Resetting CURLOPT_ERRORBUFFER before calling Aria2::doRequest

### DIFF
--- a/src/aria2.cpp
+++ b/src/aria2.cpp
@@ -111,6 +111,9 @@ Aria2::Aria2():
     curl_easy_cleanup(mp_curl);
     throw std::runtime_error("Cannot connect to aria2c rpc. Aria2c launch cmd : " + launchCmd);
   }
+
+  // Resetting CURLOPT_ERRORBUFFER to the default value
+  curl_easy_setopt(mp_curl, CURLOPT_ERRORBUFFER, nullptr);
 }
 
 Aria2::~Aria2()


### PR DESCRIPTION
Fix for https://github.com/kiwix/kiwix-desktop/issues/513 (Kiwix always crashing after exit on Fedora).
Crash was caused by using of this gcc flags: `-fstack-protector-strong` or/and `-fstack-clash-protection`.