### PR TITLE
Adjust body padding-top for taskbar

### DIFF
--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -124,7 +124,7 @@ label[for=kiwixsearchbox] {
 }
 
 body {
-    padding-top: 3em !important;
+    padding-top: calc(3em - 5px) !important;
 }
 
 /* Try to fix buggy stuff in jquery-ui autocomplete */


### PR DESCRIPTION
taskbar is placed *above* content using a `padding-top: 3em;` rule
Currently, in regular case, padding-top is too large and leaves ~4/5px between the
taskbar and the content.
This fixes it by using a `calc()` rule to eliminate this extra space

Reported at https://github.com/openzim/zimit/issues/41