### PR TITLE
Support 'video/*' * 'audio/*' mimetypes in getMediaCount()

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -121,7 +121,9 @@ unsigned int Reader::getMediaCount() const
   unsigned int counter = 0;
 
   for (auto &pair:counterMap) {
-    if (startsWith(pair.first, "image/")) {
+    if (startsWith(pair.first, "image/") ||
+        startsWith(pair.first, "video/") ||
+        startsWith(pair.first, "audio/")) {
       counter += pair.second;
     }
   }


### PR DESCRIPTION
Fixes #438 