### PR TITLE
Fix taskbar insertion in case of '<head>' attributes

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -189,7 +189,7 @@ void ContentResponse::introduce_taskbar()
   auto head_content = render_template(RESOURCE::templates::head_part_html, data);
   m_content = appendToFirstOccurence(
     m_content,
-    "<head>",
+    "<head[^>]*>",
     head_content);
 
   auto taskbar_part = render_template(RESOURCE::templates::taskbar_part_html, data);


### PR DESCRIPTION
Fixes https://github.com/kiwix/kiwix-tools/issues/412