### PR TITLE
Bump-up version (and libzim required version)

### DIFF
--- a/android-kiwix-lib-publisher/kiwixLibAndroid/build.gradle
+++ b/android-kiwix-lib-publisher/kiwixLibAndroid/build.gradle
@@ -26,7 +26,7 @@ task writePom {
     project {
         groupId 'org.kiwix.kiwixlib'
         artifactId 'kiwixlib'
-        version '9.4.1' + (System.env.KIWIXLIB_BUILDVERSION == null ? '' : '-'+System.env.KIWIXLIB_BUILDVERSION)
+        version '9.5.0' + (System.env.KIWIXLIB_BUILDVERSION == null ? '' : '-'+System.env.KIWIXLIB_BUILDVERSION)
         packaging 'aar'
         name 'kiwixlib'
         url 'https://github.com/kiwix/kiwix-lib'

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('kiwix-lib', 'cpp',
-  version : '9.4.1', # Also change this in android-kiwix-lib-publisher/kiwixLibAndroid/build.gradle
+  version : '9.5.0', # Also change this in android-kiwix-lib-publisher/kiwixLibAndroid/build.gradle
   license : 'GPLv3+',
   default_options : ['c_std=c11', 'cpp_std=c++11', 'werror=true'])
 
@@ -43,7 +43,7 @@ else
   error('Cannot found header mustache.hpp')
 endif
 
-libzim_dep = dependency('libzim', version : '>=6.3.0', static:static_deps)
+libzim_dep = dependency('libzim', version : '>=7.0.0', static:static_deps)
 if not compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN')
   error('Libzim seems to be compiled without xapian. Xapian support is mandatory.')
 endif


### PR DESCRIPTION
With major changes in libzim API all dependent libraries have no other choice but to follow suit.