### PR TITLE
added root functionality for block external link feature

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -221,9 +221,9 @@ void ContentResponse::inject_externallinks_blocker()
   kainjow::mustache::data data;
   data.set("root", m_root);
   auto script_tag = render_template(RESOURCE::templates::external_blocker_part_html, data);
-  m_content = appendToFirstOccurence(
+  m_content = prependToFirstOccurence(
     m_content,
-    "<head>",
+    "</head[ \\t]*>",
     script_tag);
 }
 

--- a/static/skin/block_external.js
+++ b/static/skin/block_external.js
@@ -1,5 +1,6 @@
+const root = document.querySelector( `link[type='root']` ).getAttribute("href");
 // `block_path` variable used by openzim/warc2zim to detect whether URL blocking is enabled or not
-var block_path = "/catch/external";
+var block_path = `${root}/catch/external`;
 // called only on external links
 function capture_event(e, target) { target.setAttribute("href", encodeURI(block_path + "?source=" + target.href)); }
 


### PR DESCRIPTION
@kelson42 this resolves #407 
I have one more point currently `<link type="root" href="{{root}}">` is placed in head_part.html which is rendered only if `m_withTaskbar` is true,
it should be moved to `index.html` according to me so should I do that as well in this PR?