### PR TITLE
Library::removeBookById() updates the reader list and the search DB

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -106,6 +106,7 @@ bool Library::removeBookmark(const std::string& zimId, const std::string& url)
 
 bool Library::removeBookById(const std::string& id)
 {
+  m_bookDB->delete_document("Q" + id);
   m_readers.erase(id);
   return m_books.erase(id) == 1;
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -106,6 +106,7 @@ bool Library::removeBookmark(const std::string& zimId, const std::string& url)
 
 bool Library::removeBookById(const std::string& id)
 {
+  m_readers.erase(id);
   return m_books.erase(id) == 1;
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -331,7 +331,7 @@ Library::BookIdCollection Library::filter(const Filter& filter)
 {
   BookIdCollection result;
   for(auto id : getBooksByTitleOrDescription(filter)) {
-    if(filter.acceptByNonQueryCriteria(m_books[id])) {
+    if(filter.acceptByNonQueryCriteria(m_books.at(id))) {
       result.push_back(id);
     }
   }

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -310,4 +310,22 @@ TEST_F(XmlLibraryTest, removeBookByIdDropsTheReader)
   EXPECT_THROW(lib.getReaderById("raycharles"), std::out_of_range);
 };
 
+TEST_F(XmlLibraryTest, removeBookByIdUpdatesTheSearchDB)
+{
+  kiwix::Filter f;
+  f.local(true).valid(true).query(R"(title:"ray charles")", false);
+
+  EXPECT_NO_THROW(lib.getBookById("raycharles"));
+  EXPECT_EQ(1U, lib.filter(f).size());
+
+  lib.removeBookById("raycharles");
+
+  EXPECT_THROW(lib.getBookById("raycharles"), std::out_of_range);
+  EXPECT_EQ(0U, lib.filter(f).size());
+
+  // make sure that Library::filter() doesn't add an empty book with
+  // an id surviving in the search DB
+  EXPECT_THROW(lib.getBookById("raycharles"), std::out_of_range);
+};
+
 };

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -283,4 +283,31 @@ TEST_F(LibraryTest, getBookByPath)
   EXPECT_EQ(lib.getBookByPath(path).getId(), book.getId());
   EXPECT_THROW(lib.getBookByPath("non/existant/path.zim"), std::out_of_range);
 }
+
+class XmlLibraryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+     kiwix::Manager manager(&lib);
+     manager.readFile( "./test/library.xml", true, true);
+  }
+
+  kiwix::Library lib;
+};
+
+TEST_F(XmlLibraryTest, removeBookByIdRemovesTheBook)
+{
+  EXPECT_EQ(3U, lib.getBookCount(true, true));
+  EXPECT_NO_THROW(lib.getBookById("raycharles"));
+  lib.removeBookById("raycharles");
+  EXPECT_EQ(2U, lib.getBookCount(true, true));
+  EXPECT_THROW(lib.getBookById("raycharles"), std::out_of_range);
+};
+
+TEST_F(XmlLibraryTest, removeBookByIdDropsTheReader)
+{
+  EXPECT_NE(nullptr, lib.getReaderById("raycharles"));
+  lib.removeBookById("raycharles");
+  EXPECT_THROW(lib.getReaderById("raycharles"), std::out_of_range);
+};
+
 };


### PR DESCRIPTION
Fixes #478 

I added a new test-suite `XmlLibraryTest` so that I could make use of the `Library::getReaderById()` method (a library constructed from an OPDS stream doesn't contain local books).