### PR TITLE
kiwix::Manager's readXml() and readOpds() methods respect the immutability of their read-only input parameters

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -80,7 +80,7 @@ bool Manager::readXml(const std::string& xml,
 {
   pugi::xml_document doc;
   pugi::xml_parse_result result
-      = doc.load_buffer_inplace((void*)xml.data(), xml.size());
+      = doc.load_buffer((void*)xml.data(), xml.size());
 
   if (result) {
     this->parseXmlDom(doc, readOnly, libraryPath, trustLibrary);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -124,7 +124,7 @@ bool Manager::readOpds(const std::string& content, const std::string& urlHost)
 {
   pugi::xml_document doc;
   pugi::xml_parse_result result
-      = doc.load_buffer_inplace((void*)content.data(), content.size());
+      = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
     this->parseOpdsDom(doc, urlHost);

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -14,7 +14,7 @@ TEST(ManagerTest, addBookFromPathAndGetIdTest)
     ASSERT_NE(bookId, "");
     kiwix::Book book = lib.getBookById(bookId);
     EXPECT_EQ(book.getPath(), computeAbsolutePath("", "./test/example.zim"));
-    
+
     const std::string pathToSave = "./pathToSave";
     const std::string url = "url";
     bookId = manager.addBookFromPathAndGetId("./test/example.zim", pathToSave, url, true);
@@ -22,4 +22,47 @@ TEST(ManagerTest, addBookFromPathAndGetIdTest)
     auto savedPath = computeAbsolutePath(removeLastPathElement(manager.writableLibraryPath), pathToSave);
     EXPECT_EQ(book.getPath(), savedPath);
     EXPECT_EQ(book.getUrl(), url);
+}
+
+const char sampleLibraryXML[] = R"(
+<library version="1.0">
+  <book
+        id="0d0bcd57-d3f6-cb22-44cc-a723ccb4e1b2"
+        path="zimfiles/unittest.zim"
+        url="https://example.com/zimfiles/unittest.zim"
+        title="Unit Test"
+        description="Wikipedia articles about unit testing"
+        language="eng"
+        creator="Wikipedia"
+        publisher="Kiwix"
+        date="2020-03-31"
+        name="wikipedia_en_unit_testing"
+        tags="unittest;wikipedia"
+        articleCount="123"
+        mediaCount="45"
+        size="678"
+      ></book>
+</library>
+)";
+
+TEST(ManagerTest, readXml)
+{
+    kiwix::Library lib;
+    kiwix::Manager manager = kiwix::Manager(&lib);
+
+    EXPECT_EQ(true, manager.readXml(sampleLibraryXML, true, "/data/lib.xml", true));
+    kiwix::Book book = lib.getBookById("0d0bcd57-d3f6-cb22-44cc-a723ccb4e1b2");
+    EXPECT_EQ("/data/zimfiles/unittest.zim", book.getPath());
+    EXPECT_EQ("https://example.com/zimfiles/unittest.zim", book.getUrl());
+    EXPECT_EQ("Unit Test", book.getTitle());
+    EXPECT_EQ("Wikipedia articles about unit testing", book.getDescription());
+    EXPECT_EQ("eng", book.getLanguage());
+    EXPECT_EQ("Wikipedia", book.getCreator());
+    EXPECT_EQ("Kiwix", book.getPublisher());
+    EXPECT_EQ("2020-03-31", book.getDate());
+    EXPECT_EQ("wikipedia_en_unit_testing", book.getName());
+    EXPECT_EQ("unittest;wikipedia", book.getTags());
+    EXPECT_EQ(123U, book.getArticleCount());
+    EXPECT_EQ(45U, book.getMediaCount());
+    EXPECT_EQ(678U*1024, book.getSize());
 }


### PR DESCRIPTION
Fixes #462