### PR TITLE
Fully xapian powered catalog search

### DIFF
--- a/include/library.h
+++ b/include/library.h
@@ -114,7 +114,7 @@ class Filter {
 private:
     friend class Library;
 
-    bool acceptByNonQueryCriteria(const Book& book) const;
+    bool accept(const Book& book) const;
 };
 
 
@@ -309,7 +309,7 @@ class Library
   friend class libXMLDumper;
 
 private: // functions
-  BookIdCollection getBooksByTitleOrDescription(const Filter& filter);
+  BookIdCollection filterViaBookDB(const Filter& filter);
   void updateBookDB(const Book& book);
 };
 

--- a/include/library.h
+++ b/include/library.h
@@ -35,6 +35,7 @@ namespace kiwix
 {
 
 class OPDSDumper;
+class Library;
 
 enum supportedListSortBy { UNSORTED, TITLE, SIZE, DATE, CREATOR, PUBLISHER };
 enum supportedListMode {
@@ -109,6 +110,9 @@ class Filter {
     bool hasQuery() const;
     const std::string& getQuery() const { return _query; }
     bool queryIsPartial() const { return _queryIsPartial; }
+
+private:
+    friend class Library;
 
     bool accept(const Book& book) const;
     bool acceptByQueryOnly(const Book& book) const;

--- a/include/library.h
+++ b/include/library.h
@@ -114,8 +114,6 @@ class Filter {
 private:
     friend class Library;
 
-    bool accept(const Book& book) const;
-    bool acceptByQueryOnly(const Book& book) const;
     bool acceptByNonQueryCriteria(const Book& book) const;
 };
 

--- a/include/library.h
+++ b/include/library.h
@@ -120,6 +120,9 @@ class Filter {
     bool hasLang() const;
     const std::string& getLang() const { return _lang; }
 
+    bool hasPublisher() const;
+    const std::string& getPublisher() const { return _publisher; }
+
 private:
     friend class Library;
 

--- a/include/library.h
+++ b/include/library.h
@@ -117,6 +117,9 @@ class Filter {
     bool hasCategory() const;
     const std::string& getCategory() const { return _category; }
 
+    bool hasLang() const;
+    const std::string& getLang() const { return _lang; }
+
 private:
     friend class Library;
 

--- a/include/library.h
+++ b/include/library.h
@@ -129,6 +129,9 @@ class Filter {
     bool hasCreator() const;
     const std::string& getCreator() const { return _creator; }
 
+    const Tags& getAcceptTags() const { return _acceptTags; }
+    const Tags& getRejectTags() const { return _rejectTags; }
+
 private: // functions
     friend class Library;
 

--- a/include/library.h
+++ b/include/library.h
@@ -49,10 +49,13 @@ enum supportedListMode {
 };
 
 class Filter {
-  private:
+  public: // types
+    using Tags = std::vector<std::string>;
+
+  private: // data
     uint64_t activeFilters;
-    std::vector<std::string> _acceptTags;
-    std::vector<std::string> _rejectTags;
+    Tags _acceptTags;
+    Tags _rejectTags;
     std::string _category;
     std::string _lang;
     std::string _publisher;
@@ -62,7 +65,7 @@ class Filter {
     bool _queryIsPartial;
     std::string _name;
 
-  public:
+  public: // functions
     Filter();
     ~Filter() = default;
 
@@ -96,8 +99,8 @@ class Filter {
     /**
      * Set the filter to only accept book with corresponding tag.
      */
-    Filter& acceptTags(std::vector<std::string> tags);
-    Filter& rejectTags(std::vector<std::string> tags);
+    Filter& acceptTags(const Tags& tags);
+    Filter& rejectTags(const Tags& tags);
 
     Filter& category(std::string category);
     Filter& lang(std::string lang);
@@ -126,7 +129,7 @@ class Filter {
     bool hasCreator() const;
     const std::string& getCreator() const { return _creator; }
 
-private:
+private: // functions
     friend class Library;
 
     bool accept(const Book& book) const;

--- a/include/library.h
+++ b/include/library.h
@@ -111,6 +111,9 @@ class Filter {
     const std::string& getQuery() const { return _query; }
     bool queryIsPartial() const { return _queryIsPartial; }
 
+    bool hasName() const;
+    const std::string& getName() const { return _name; }
+
 private:
     friend class Library;
 

--- a/include/library.h
+++ b/include/library.h
@@ -114,6 +114,9 @@ class Filter {
     bool hasName() const;
     const std::string& getName() const { return _name; }
 
+    bool hasCategory() const;
+    const std::string& getCategory() const { return _category; }
+
 private:
     friend class Library;
 

--- a/include/library.h
+++ b/include/library.h
@@ -123,6 +123,9 @@ class Filter {
     bool hasPublisher() const;
     const std::string& getPublisher() const { return _publisher; }
 
+    bool hasCreator() const;
+    const std::string& getCreator() const { return _creator; }
+
 private:
     friend class Library;
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -596,11 +596,6 @@ bool Filter::hasQuery() const
   return ACTIVE(QUERY);
 }
 
-bool Filter::accept(const Book& book) const
-{
-  return acceptByNonQueryCriteria(book) && acceptByQueryOnly(book);
-}
-
 bool Filter::acceptByNonQueryCriteria(const Book& book) const
 {
   auto local = !book.getPath().empty();
@@ -645,17 +640,6 @@ bool Filter::acceptByNonQueryCriteria(const Book& book) const
     }
   }
   return true;
-}
-
-bool Filter::acceptByQueryOnly(const Book& book) const
-{
-  if ( ACTIVE(QUERY)
-    && !(matchRegex(book.getTitle(), "\\Q" + _query + "\\E")
-        || matchRegex(book.getDescription(), "\\Q" + _query + "\\E")))
-    return false;
-
-  return true;
-
 }
 
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -350,10 +350,11 @@ Xapian::Query buildXapianQueryFromFilterQuery(const Filter& filter)
   //queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_SOME);
   const auto flags = Xapian::QueryParser::FLAG_PHRASE
                    | Xapian::QueryParser::FLAG_BOOLEAN
+                   | Xapian::QueryParser::FLAG_BOOLEAN_ANY_CASE
                    | Xapian::QueryParser::FLAG_LOVEHATE
                    | Xapian::QueryParser::FLAG_WILDCARD
                    | partialQueryFlag;
-  return queryParser.parse_query(filter.getQuery(), flags);
+  return queryParser.parse_query(normalizeText(filter.getQuery()), flags);
 }
 
 Xapian::Query nameQuery(const std::string& name)

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -278,31 +278,29 @@ void Library::updateBookDB(const Book& book)
 
   const std::string title = normalizeText(book.getTitle());
   const std::string desc = normalizeText(book.getDescription());
-  const std::string name = normalizeText(book.getName());
-  const std::string category = normalizeText(book.getCategory());
-  const std::string publisher = normalizeText(book.getPublisher());
-  const std::string creator = normalizeText(book.getCreator());
-  const std::string tags = normalizeText(book.getTags());
-  doc.set_data(book.getId());
 
-  indexer.index_text(title, 1, "S");
-  indexer.index_text(desc, 1, "XD");
-  indexer.index_text(name, 1, "XN");
-  indexer.index_text(category, 1, "XC");
-  indexer.index_text(lang, 1, "L");
-  indexer.index_text(publisher, 1, "XP");
-  indexer.index_text(creator, 1, "A");
-
-  for ( const auto& tag : split(tags, ";") )
-    doc.add_boolean_term("XT" + tag);
-
-  // Index fields without prefixes for general search
+  // Index title and description without prefixes for general search
   indexer.index_text(title);
   indexer.increase_termpos();
   indexer.index_text(desc);
 
+  // Index all fields for field-based search
+  indexer.index_text(title, 1, "S");
+  indexer.index_text(desc,  1, "XD");
+  indexer.index_text(lang,  1, "L");
+  indexer.index_text(normalizeText(book.getCreator()),   1, "A");
+  indexer.index_text(normalizeText(book.getPublisher()), 1, "XP");
+  indexer.index_text(normalizeText(book.getName()),      1, "XN");
+  indexer.index_text(normalizeText(book.getCategory()),  1, "XC");
+
+  for ( const auto& tag : split(normalizeText(book.getTags()), ";") )
+    doc.add_boolean_term("XT" + tag);
+
   const std::string idterm = "Q" + book.getId();
   doc.add_boolean_term(idterm);
+
+  doc.set_data(book.getId());
+
   m_bookDB->replace_document(idterm, doc);
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -278,11 +278,11 @@ void Library::updateBookDB(const Book& book)
 
   const std::string title = normalizeText(book.getTitle());
   const std::string desc = normalizeText(book.getDescription());
-  const std::string name = book.getName(); // this is supposed to be normalized
-  const std::string category = book.getCategory(); // this is supposed to be normalized
+  const std::string name = normalizeText(book.getName());
+  const std::string category = normalizeText(book.getCategory());
   const std::string publisher = normalizeText(book.getPublisher());
   const std::string creator = normalizeText(book.getCreator());
-  const std::string tags = book.getTags(); // normalization not needed
+  const std::string tags = normalizeText(book.getTags());
   doc.add_value(0, title);
   doc.add_value(1, desc);
   doc.add_value(2, name);
@@ -359,17 +359,17 @@ Xapian::Query buildXapianQueryFromFilterQuery(const Filter& filter)
 
 Xapian::Query nameQuery(const std::string& name)
 {
-  return Xapian::Query("XN" + name);
+  return Xapian::Query("XN" + normalizeText(name));
 }
 
 Xapian::Query categoryQuery(const std::string& category)
 {
-  return Xapian::Query("XC" + category);
+  return Xapian::Query("XC" + normalizeText(category));
 }
 
 Xapian::Query langQuery(const std::string& lang)
 {
-  return Xapian::Query("L" + lang);
+  return Xapian::Query("L" + normalizeText(lang));
 }
 
 Xapian::Query publisherQuery(const std::string& publisher)
@@ -397,12 +397,12 @@ Xapian::Query tagsQuery(const Filter::Tags& acceptTags, const Filter::Tags& reje
   Xapian::Query q = Xapian::Query(std::string());
   if (!acceptTags.empty()) {
     for ( const auto& tag : acceptTags )
-      q &= Xapian::Query("XT" + tag);
+      q &= Xapian::Query("XT" + normalizeText(tag));
   }
 
   if (!rejectTags.empty()) {
     for ( const auto& tag : rejectTags )
-      q = Xapian::Query(Xapian::Query::OP_AND_NOT, q, "XT" + tag);
+      q = Xapian::Query(Xapian::Query::OP_AND_NOT, q, "XT" + normalizeText(tag));
   }
   return q;
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -624,14 +624,14 @@ Filter& Filter::valid(bool accept)
   return *this;
 }
 
-Filter& Filter::acceptTags(std::vector<std::string> tags)
+Filter& Filter::acceptTags(const Tags& tags)
 {
   _acceptTags = tags;
   activeFilters |= ACCEPTTAGS;
   return *this;
 }
 
-Filter& Filter::rejectTags(std::vector<std::string> tags)
+Filter& Filter::rejectTags(const Tags& tags)
 {
   _rejectTags = tags;
   activeFilters |= REJECTTAGS;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -295,7 +295,7 @@ void Library::updateBookDB(const Book& book)
   m_bookDB->replace_document(idterm, doc);
 }
 
-Library::BookIdCollection Library::getBooksByTitleOrDescription(const Filter& filter)
+Library::BookIdCollection Library::filterViaBookDB(const Filter& filter)
 {
   if ( !filter.hasQuery() )
     return getBooksIds();
@@ -331,8 +331,8 @@ Library::BookIdCollection Library::getBooksByTitleOrDescription(const Filter& fi
 Library::BookIdCollection Library::filter(const Filter& filter)
 {
   BookIdCollection result;
-  for(auto id : getBooksByTitleOrDescription(filter)) {
-    if(filter.acceptByNonQueryCriteria(m_books.at(id))) {
+  for(auto id : filterViaBookDB(filter)) {
+    if(filter.accept(m_books.at(id))) {
       result.push_back(id);
     }
   }
@@ -596,7 +596,7 @@ bool Filter::hasQuery() const
   return ACTIVE(QUERY);
 }
 
-bool Filter::acceptByNonQueryCriteria(const Book& book) const
+bool Filter::accept(const Book& book) const
 {
   auto local = !book.getPath().empty();
   FILTER(_LOCAL, local)

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -283,14 +283,6 @@ void Library::updateBookDB(const Book& book)
   const std::string publisher = normalizeText(book.getPublisher());
   const std::string creator = normalizeText(book.getCreator());
   const std::string tags = normalizeText(book.getTags());
-  doc.add_value(0, title);
-  doc.add_value(1, desc);
-  doc.add_value(2, name);
-  doc.add_value(3, category);
-  doc.add_value(4, lang);
-  doc.add_value(5, publisher);
-  doc.add_value(6, creator);
-  doc.add_value(7, tags);
   doc.set_data(book.getId());
 
   indexer.index_text(title, 1, "S");

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -364,9 +364,11 @@ Xapian::Query langQuery(const std::string& lang)
 Xapian::Query publisherQuery(const std::string& publisher)
 {
   Xapian::QueryParser queryParser;
-  queryParser.set_default_op(Xapian::Query::OP_PHRASE);
+  queryParser.set_default_op(Xapian::Query::OP_OR);
+  queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_NONE);
   const auto flags = 0;
-  return queryParser.parse_query(normalizeText(publisher), flags, "XP");
+  const auto q = queryParser.parse_query(normalizeText(publisher), flags, "XP");
+  return Xapian::Query(Xapian::Query::OP_PHRASE, q.get_terms_begin(), q.get_terms_end(), q.get_length());
 }
 
 Xapian::Query buildXapianQuery(const Filter& filter)

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -505,10 +505,20 @@ TEST_F(LibraryTest, filterByMaxSize)
 
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {
-  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wiki"),
-    "Granblue Fantasy Wiki"
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wikipedia"),
+    "Encyclopédie de la Tunisie",
+    "Géographie par Wikipédia",
+    "Ray Charles"
   );
 
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wikipedia").maxSize(100000000UL),
+    "Encyclopédie de la Tunisie",
+    "Ray Charles"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wikipedia").maxSize(100000000UL).local(false),
+    "Encyclopédie de la Tunisie"
+  );
 }
 
 TEST_F(LibraryTest, getBookByPath)

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -206,7 +206,7 @@ const char sampleLibraryXML[] = R"(
         description="An eXaMpLe book added to the catalog via XML"
         language="deu"
         creator="Wikibooks"
-        publisher="Kiwix Enthusiasts"
+        publisher="Kiwix & Some Enthusiasts"
         date="2021-04-11"
         name="wikibooks_de"
         tags="unittest;wikibooks;_category:wikibooks"
@@ -499,10 +499,10 @@ TEST_F(LibraryTest, filterByPublisher)
   );
 
   // filtering by publisher requires a full phrase match
-  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwix Enthusiasts"),
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwix & Some Enthusiasts"),
     "An example ZIM archive"
   );
-  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Enthusiasts Kiwix"),
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Some Enthusiasts & Kiwix"),
     /* no results */
   );
 

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -481,6 +481,13 @@ TEST_F(LibraryTest, filterByPublisher)
   );
 }
 
+TEST_F(LibraryTest, filterByName)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().name("wikibooks_de"),
+    "An example ZIM archive"
+  );
+}
+
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wiki"),

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -181,6 +181,43 @@ const char * sampleOpdsStream = R"(
 
 )";
 
+const char sampleLibraryXML[] = R"(
+<library version="1.0">
+  <book
+        id="raycharles"
+        path="./zimfile.zim"
+        url="https://github.com/kiwix/kiwix-lib/raw/master/test/data/zimfile.zim"
+        title="Ray Charles"
+        description="Wikipedia articles about Ray Charles"
+        language="eng"
+        creator="Wikipedia"
+        publisher="Kiwix"
+        date="2020-03-31"
+        name="wikipedia_en_ray_charles"
+        tags="wikipedia;_category:wikipedia;_pictures:no"
+        articleCount="284"
+        mediaCount="2"
+        size="556"
+      ></book>
+  <book
+        id="example"
+        path="./example.zim"
+        url="https://github.com/kiwix/kiwix-lib/raw/master/test/data/example.zim"
+        title="An example ZIM archive"
+        description="An eXaMpLe book added to the catalog via XML"
+        language="deu"
+        creator="Wikibooks"
+        publisher="Kiwix"
+        date="2021-04-11"
+        name="wikibooks_de"
+        tags="unittest;wikibooks;_category:wikibooks"
+        articleCount="12"
+        mediaCount="0"
+        size="126"
+      ></book>
+</library>
+)";
+
 #include "../include/library.h"
 #include "../include/manager.h"
 #include "../include/bookmark.h"
@@ -196,6 +233,7 @@ class LibraryTest : public ::testing::Test {
   void SetUp() override {
      kiwix::Manager manager(&lib);
      manager.readOpds(sampleOpdsStream, "foo.urlHost");
+     manager.readXml(sampleLibraryXML, true, "/data/library.xml", true);
   }
 
     kiwix::Bookmark createBookmark(const std::string &id) {
@@ -237,10 +275,10 @@ TEST_F(LibraryTest, getBookMarksTest)
 
 TEST_F(LibraryTest, sanityCheck)
 {
-  EXPECT_EQ(lib.getBookCount(true, true), 10U);
-  EXPECT_EQ(lib.getBooksLanguages().size(), 2U);
-  EXPECT_EQ(lib.getBooksCreators().size(), 8U);
-  EXPECT_EQ(lib.getBooksPublishers().size(), 1U);
+  EXPECT_EQ(lib.getBookCount(true, true), 12U);
+  EXPECT_EQ(lib.getBooksLanguages().size(), 3U);
+  EXPECT_EQ(lib.getBooksCreators().size(), 9U);
+  EXPECT_EQ(lib.getBooksPublishers().size(), 2U);
 }
 
 TEST_F(LibraryTest, categoryHandling)
@@ -271,6 +309,7 @@ TEST_F(LibraryTest, filterByLanguage)
     "Islam Stack Exchange",
     "Movies & TV Stack Exchange",
     "Mythology & Folklore Stack Exchange",
+    "Ray Charles",
     "TED talks - Business"
   );
 }
@@ -305,7 +344,8 @@ TEST_F(LibraryTest, filterByTags)
   EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"wikipedia"}),
     "Encyclopédie de la Tunisie",
     "Géographie par Wikipédia",
-    "Mathématiques"
+    "Mathématiques",
+    "Ray Charles"
   );
 
   EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"wikipedia", "nopic"}),
@@ -314,7 +354,8 @@ TEST_F(LibraryTest, filterByTags)
   );
 
   EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"wikipedia"}).rejectTags({"nopic"}),
-    "Encyclopédie de la Tunisie"
+    "Encyclopédie de la Tunisie",
+    "Ray Charles"
   );
 }
 
@@ -352,6 +393,7 @@ TEST_F(LibraryTest, filterByQuery)
     "Encyclopédie de la Tunisie",
     "Granblue Fantasy Wiki",
     "Géographie par Wikipédia",
+    "Ray Charles",
     "Wikiquote"
   );
 
@@ -367,7 +409,8 @@ TEST_F(LibraryTest, filterByCreator)
   EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Wikipedia"),
     "Encyclopédie de la Tunisie",
     "Géographie par Wikipédia",
-    "Mathématiques"
+    "Mathématiques",
+    "Ray Charles"
   );
 
   // filtering by creator requires full match of the search term

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -252,12 +252,15 @@ TEST_F(LibraryTest, categoryHandling)
   EXPECT_EQ("category_element_overrides_tags", lib.getBookById("14829621-c490-c376-0792-9de558b57efa").getCategory());
 }
 
-TEST_F(LibraryTest, filterCheck)
+TEST_F(LibraryTest, emptyFilter)
 {
-  auto bookIds = lib.filter(kiwix::Filter());
+  const auto bookIds = lib.filter(kiwix::Filter());
   EXPECT_EQ(bookIds, lib.getBooksIds());
+}
 
-  bookIds = lib.filter(kiwix::Filter().lang("eng"));
+TEST_F(LibraryTest, filterByLanguage)
+{
+  const auto bookIds = lib.filter(kiwix::Filter().lang("eng"));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({
               "Granblue Fantasy Wiki",
@@ -267,8 +270,11 @@ TEST_F(LibraryTest, filterCheck)
               "TED talks - Business"
             })
   );
+}
 
-  bookIds = lib.filter(kiwix::Filter().acceptTags({"stackexchange"}));
+TEST_F(LibraryTest, filterByTags)
+{
+  auto bookIds = lib.filter(kiwix::Filter().acceptTags({"stackexchange"}));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({
               "Islam Stack Exchange",
@@ -300,8 +306,12 @@ TEST_F(LibraryTest, filterCheck)
               "Encyclopédie de la Tunisie"
             })
   );
+}
 
-  bookIds = lib.filter(kiwix::Filter().query("folklore"));
+
+TEST_F(LibraryTest, filterByQuery)
+{
+  auto bookIds = lib.filter(kiwix::Filter().query("folklore"));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({
               "Mythology & Folklore Stack Exchange"
@@ -318,9 +328,12 @@ TEST_F(LibraryTest, filterCheck)
               "Wikiquote"
             })
   );
+}
 
 
-  bookIds = lib.filter(kiwix::Filter().query("Wiki").creator("Wiki"));
+TEST_F(LibraryTest, filterByMultipleCriteria)
+{
+  auto bookIds = lib.filter(kiwix::Filter().query("Wiki").creator("Wiki"));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({
               "Granblue Fantasy Wiki"

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -206,7 +206,7 @@ const char sampleLibraryXML[] = R"(
         description="An eXaMpLe book added to the catalog via XML"
         language="deu"
         creator="Wikibooks"
-        publisher="Kiwix"
+        publisher="Kiwix Enthusiasts"
         date="2021-04-11"
         name="wikibooks_de"
         tags="unittest;wikibooks;_category:wikibooks"
@@ -277,7 +277,7 @@ TEST_F(LibraryTest, sanityCheck)
   EXPECT_EQ(lib.getBookCount(true, true), 12U);
   EXPECT_EQ(lib.getBooksLanguages().size(), 3U);
   EXPECT_EQ(lib.getBooksCreators().size(), 9U);
-  EXPECT_EQ(lib.getBooksPublishers().size(), 2U);
+  EXPECT_EQ(lib.getBooksPublishers().size(), 3U);
 }
 
 TEST_F(LibraryTest, categoryHandling)
@@ -491,6 +491,34 @@ TEST_F(LibraryTest, filterByPublisher)
   EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwix"),
     "An example ZIM archive",
     "Ray Charles"
+  );
+
+  // filtering by publisher requires full match of the search term
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwi"),
+    /* no results */
+  );
+
+  // filtering by publisher requires a full phrase match
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwix Enthusiasts"),
+    "An example ZIM archive"
+  );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Enthusiasts Kiwix"),
+    /* no results */
+  );
+
+  // filtering by publisher is case and diacritics insensitive
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("kîWIx"),
+    "An example ZIM archive",
+    "Ray Charles"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("publisher:kiwix"),
+    "An example ZIM archive",
+    "Ray Charles"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("kiwix"),
+    /* no results */
   );
 }
 

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -202,7 +202,6 @@ const char sampleLibraryXML[] = R"(
   <book
         id="example"
         path="./example.zim"
-        url="https://github.com/kiwix/kiwix-lib/raw/master/test/data/example.zim"
         title="An example ZIM archive"
         description="An eXaMpLe book added to the catalog via XML"
         language="deu"
@@ -301,6 +300,48 @@ TEST_F(LibraryTest, emptyFilter)
           ids2Titles(lib.filter(f)),         \
           TitleCollection({ __VA_ARGS__ })   \
         )
+
+TEST_F(LibraryTest, filterLocal)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().local(true),
+    "An example ZIM archive",
+    "Ray Charles"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().local(false),
+    "Encyclopédie de la Tunisie",
+    "Granblue Fantasy Wiki",
+    "Géographie par Wikipédia",
+    "Islam Stack Exchange",
+    "Mathématiques",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange",
+    "TED talks - Business",
+    "Tania Louis",
+    "Wikiquote"
+  );
+}
+
+TEST_F(LibraryTest, filterRemote)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().remote(true),
+    "Encyclopédie de la Tunisie",
+    "Granblue Fantasy Wiki",
+    "Géographie par Wikipédia",
+    "Islam Stack Exchange",
+    "Mathématiques",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange",
+    "Ray Charles",
+    "TED talks - Business",
+    "Tania Louis",
+    "Wikiquote"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().remote(false),
+    "An example ZIM archive"
+  );
+}
 
 TEST_F(LibraryTest, filterByLanguage)
 {

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -311,14 +311,45 @@ TEST_F(LibraryTest, filterByTags)
 
 TEST_F(LibraryTest, filterByQuery)
 {
-  auto bookIds = lib.filter(kiwix::Filter().query("folklore"));
+  // filtering by query checks the title
+  auto bookIds = lib.filter(kiwix::Filter().query("Exchange"));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({
+              "Islam Stack Exchange",
+              "Movies & TV Stack Exchange",
               "Mythology & Folklore Stack Exchange"
             })
   );
 
+  // filtering by query checks the description/summary
+  bookIds = lib.filter(kiwix::Filter().query("enthusiasts"));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Movies & TV Stack Exchange",
+              "Mythology & Folklore Stack Exchange"
+            })
+  );
 
+  // filtering by query is case insensitive on titles
+  bookIds = lib.filter(kiwix::Filter().query("ExcHANge"));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Islam Stack Exchange",
+              "Movies & TV Stack Exchange",
+              "Mythology & Folklore Stack Exchange"
+            })
+  );
+
+  // filtering by query is case insensitive on description/summary
+  bookIds = lib.filter(kiwix::Filter().query("enTHUSiaSTS"));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Movies & TV Stack Exchange",
+              "Mythology & Folklore Stack Exchange"
+            })
+  );
+
+  // by default, filtering by query assumes partial query
   bookIds = lib.filter(kiwix::Filter().query("Wiki"));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({
@@ -326,6 +357,14 @@ TEST_F(LibraryTest, filterByQuery)
               "Granblue Fantasy Wiki",
               "Géographie par Wikipédia",
               "Wikiquote"
+            })
+  );
+
+  // partial query can be disabled
+  bookIds = lib.filter(kiwix::Filter().query("Wiki", false));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Granblue Fantasy Wiki"
             })
   );
 }

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -232,7 +232,7 @@ class LibraryTest : public ::testing::Test {
   void SetUp() override {
      kiwix::Manager manager(&lib);
      manager.readOpds(sampleOpdsStream, "foo.urlHost");
-     manager.readXml(sampleLibraryXML, true, "/data/library.xml", true);
+     manager.readXml(sampleLibraryXML, true, "./test/library.xml", true);
   }
 
     kiwix::Bookmark createBookmark(const std::string &id) {
@@ -637,33 +637,24 @@ TEST_F(LibraryTest, getBookByPath)
   EXPECT_THROW(lib.getBookByPath("non/existant/path.zim"), std::out_of_range);
 }
 
-class XmlLibraryTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-     kiwix::Manager manager(&lib);
-     manager.readFile( "./test/library.xml", true, true);
-  }
-
-  kiwix::Library lib;
-};
-
-TEST_F(XmlLibraryTest, removeBookByIdRemovesTheBook)
+TEST_F(LibraryTest, removeBookByIdRemovesTheBook)
 {
-  EXPECT_EQ(3U, lib.getBookCount(true, true));
+  const auto initialBookCount = lib.getBookCount(true, true);
+  ASSERT_GT(initialBookCount, 0U);
   EXPECT_NO_THROW(lib.getBookById("raycharles"));
   lib.removeBookById("raycharles");
-  EXPECT_EQ(2U, lib.getBookCount(true, true));
+  EXPECT_EQ(initialBookCount - 1, lib.getBookCount(true, true));
   EXPECT_THROW(lib.getBookById("raycharles"), std::out_of_range);
 };
 
-TEST_F(XmlLibraryTest, removeBookByIdDropsTheReader)
+TEST_F(LibraryTest, removeBookByIdDropsTheReader)
 {
   EXPECT_NE(nullptr, lib.getReaderById("raycharles"));
   lib.removeBookById("raycharles");
   EXPECT_THROW(lib.getReaderById("raycharles"), std::out_of_range);
 };
 
-TEST_F(XmlLibraryTest, removeBookByIdUpdatesTheSearchDB)
+TEST_F(LibraryTest, removeBookByIdUpdatesTheSearchDB)
 {
   kiwix::Filter f;
   f.local(true).valid(true).query(R"(title:"ray charles")", false);

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -436,8 +436,27 @@ TEST_F(LibraryTest, filterByQuery)
     "Mythology & Folklore Stack Exchange"
   );
 
+  // filtering by query is diacritics insensitive on titles
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("mathematiques"),
+    "Mathématiques",
+  );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("èxchângé"),
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
+  );
+
   // filtering by query is case insensitive on description/summary
   EXPECT_FILTER_RESULTS(kiwix::Filter().query("enTHUSiaSTS"),
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
+  );
+
+  // filtering by query is diacritics insensitive on description/summary
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("selection"),
+    "Géographie par Wikipédia"
+  );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("enthúsïåsts"),
     "Movies & TV Stack Exchange",
     "Mythology & Folklore Stack Exchange"
   );

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -502,6 +502,15 @@ TEST_F(LibraryTest, filterByCategory)
     "Géographie par Wikipédia",
     "Mathématiques"
   );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("category:category_element_overrides_tags"),
+    "Géographie par Wikipédia",
+    "Mathématiques"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("category_element_overrides_tags"),
+    /* no results */
+  );
 }
 
 TEST_F(LibraryTest, filterByMaxSize)

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -283,6 +283,27 @@ TEST_F(LibraryTest, filterByTags)
             })
   );
 
+  // filtering by tags is case sensitive
+  bookIds = lib.filter(kiwix::Filter().acceptTags({"stackEXChange"}));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({})
+  );
+
+  // filtering by tags requires full match of the search term
+  bookIds = lib.filter(kiwix::Filter().acceptTags({"stackexch"}));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({})
+  );
+
+  // in tags with values (tag:value form) the value is an inseparable
+  // part of the tag
+  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().acceptTags({"_category"}))),
+            TitleCollection({})
+  );
+  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().acceptTags({"_category:category_defined_via_tags_only"}))),
+            TitleCollection({"Tania Louis"})
+  );
+
   bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia"}));
   EXPECT_EQ(ids2Titles(bookIds),
             TitleCollection({

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -353,6 +353,19 @@ TEST_F(LibraryTest, filterByLanguage)
     "Ray Charles",
     "TED talks - Business"
   );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("lang:eng"),
+    "Granblue Fantasy Wiki",
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange",
+    "Ray Charles",
+    "TED talks - Business"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("eng"),
+    /* no results */
+  );
 }
 
 TEST_F(LibraryTest, filterByTags)

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -258,74 +258,63 @@ TEST_F(LibraryTest, emptyFilter)
   EXPECT_EQ(bookIds, lib.getBooksIds());
 }
 
+#define EXPECT_FILTER_RESULTS(f, ...)        \
+        EXPECT_EQ(                           \
+          ids2Titles(lib.filter(f)),         \
+          TitleCollection({ __VA_ARGS__ })   \
+        )
+
 TEST_F(LibraryTest, filterByLanguage)
 {
-  const auto bookIds = lib.filter(kiwix::Filter().lang("eng"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Granblue Fantasy Wiki",
-              "Islam Stack Exchange",
-              "Movies & TV Stack Exchange",
-              "Mythology & Folklore Stack Exchange",
-              "TED talks - Business"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().lang("eng"),
+    "Granblue Fantasy Wiki",
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange",
+    "TED talks - Business"
   );
 }
 
 TEST_F(LibraryTest, filterByTags)
 {
-  auto bookIds = lib.filter(kiwix::Filter().acceptTags({"stackexchange"}));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Islam Stack Exchange",
-              "Movies & TV Stack Exchange",
-              "Mythology & Folklore Stack Exchange"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"stackexchange"}),
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
 
   // filtering by tags is case sensitive
-  bookIds = lib.filter(kiwix::Filter().acceptTags({"stackEXChange"}));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"stackEXChange"}),
+    /* no results */
   );
 
   // filtering by tags requires full match of the search term
-  bookIds = lib.filter(kiwix::Filter().acceptTags({"stackexch"}));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"stackexch"}),
+    /* no results */
   );
 
   // in tags with values (tag:value form) the value is an inseparable
   // part of the tag
-  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().acceptTags({"_category"}))),
-            TitleCollection({})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"_category"}),
+    /* no results */
   );
-  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().acceptTags({"_category:category_defined_via_tags_only"}))),
-            TitleCollection({"Tania Louis"})
-  );
-
-  bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia"}));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Encyclopédie de la Tunisie",
-              "Géographie par Wikipédia",
-              "Mathématiques"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"_category:category_defined_via_tags_only"}),
+    "Tania Louis"
   );
 
-  bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia", "nopic"}));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Géographie par Wikipédia",
-              "Mathématiques"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"wikipedia"}),
+    "Encyclopédie de la Tunisie",
+    "Géographie par Wikipédia",
+    "Mathématiques"
   );
 
-  bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia"}).rejectTags({"nopic"}));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Encyclopédie de la Tunisie"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"wikipedia", "nopic"}),
+    "Géographie par Wikipédia",
+    "Mathématiques"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"wikipedia"}).rejectTags({"nopic"}),
+    "Encyclopédie de la Tunisie"
   );
 }
 
@@ -333,102 +322,78 @@ TEST_F(LibraryTest, filterByTags)
 TEST_F(LibraryTest, filterByQuery)
 {
   // filtering by query checks the title
-  auto bookIds = lib.filter(kiwix::Filter().query("Exchange"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Islam Stack Exchange",
-              "Movies & TV Stack Exchange",
-              "Mythology & Folklore Stack Exchange"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Exchange"),
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
 
   // filtering by query checks the description/summary
-  bookIds = lib.filter(kiwix::Filter().query("enthusiasts"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Movies & TV Stack Exchange",
-              "Mythology & Folklore Stack Exchange"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("enthusiasts"),
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
 
   // filtering by query is case insensitive on titles
-  bookIds = lib.filter(kiwix::Filter().query("ExcHANge"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Islam Stack Exchange",
-              "Movies & TV Stack Exchange",
-              "Mythology & Folklore Stack Exchange"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("ExcHANge"),
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
 
   // filtering by query is case insensitive on description/summary
-  bookIds = lib.filter(kiwix::Filter().query("enTHUSiaSTS"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Movies & TV Stack Exchange",
-              "Mythology & Folklore Stack Exchange"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("enTHUSiaSTS"),
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
 
   // by default, filtering by query assumes partial query
-  bookIds = lib.filter(kiwix::Filter().query("Wiki"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Encyclopédie de la Tunisie",
-              "Granblue Fantasy Wiki",
-              "Géographie par Wikipédia",
-              "Wikiquote"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki"),
+    "Encyclopédie de la Tunisie",
+    "Granblue Fantasy Wiki",
+    "Géographie par Wikipédia",
+    "Wikiquote"
   );
 
   // partial query can be disabled
-  bookIds = lib.filter(kiwix::Filter().query("Wiki", false));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Granblue Fantasy Wiki"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki", false),
+    "Granblue Fantasy Wiki"
   );
 }
 
 
 TEST_F(LibraryTest, filterByCreator)
 {
-  auto bookIds = lib.filter(kiwix::Filter().creator("Wikipedia"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Encyclopédie de la Tunisie",
-              "Géographie par Wikipédia",
-              "Mathématiques"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Wikipedia"),
+    "Encyclopédie de la Tunisie",
+    "Géographie par Wikipédia",
+    "Mathématiques"
   );
 
   // filtering by creator requires full match of the search term
-  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("Wiki"))),
-            TitleCollection({"Granblue Fantasy Wiki"})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Wiki"),
+    "Granblue Fantasy Wiki"
   );
 
   // filtering by creator is case sensitive
-  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("wiki"))),
-            TitleCollection({})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("wiki"),
+    /* no results */
   );
 
   // filtering by creator requires full match of the full author/creator name
-  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("Stack"))),
-            TitleCollection({})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Stack"),
+    /* no results */
   );
-  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("Movies & TV Stack Exchange"))),
-            TitleCollection({"Movies & TV Stack Exchange"})
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Movies & TV Stack Exchange"),
+    "Movies & TV Stack Exchange"
   );
 }
 
 
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {
-  auto bookIds = lib.filter(kiwix::Filter().query("Wiki").creator("Wiki"));
-  EXPECT_EQ(ids2Titles(bookIds),
-            TitleCollection({
-              "Granblue Fantasy Wiki"
-            })
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wiki"),
+    "Granblue Fantasy Wiki"
   );
 
 }

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -370,6 +370,37 @@ TEST_F(LibraryTest, filterByQuery)
 }
 
 
+TEST_F(LibraryTest, filterByCreator)
+{
+  auto bookIds = lib.filter(kiwix::Filter().creator("Wikipedia"));
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Encyclopédie de la Tunisie",
+              "Géographie par Wikipédia",
+              "Mathématiques"
+            })
+  );
+
+  // filtering by creator requires full match of the search term
+  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("Wiki"))),
+            TitleCollection({"Granblue Fantasy Wiki"})
+  );
+
+  // filtering by creator is case sensitive
+  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("wiki"))),
+            TitleCollection({})
+  );
+
+  // filtering by creator requires full match of the full author/creator name
+  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("Stack"))),
+            TitleCollection({})
+  );
+  EXPECT_EQ(ids2Titles(lib.filter(kiwix::Filter().creator("Movies & TV Stack Exchange"))),
+            TitleCollection({"Movies & TV Stack Exchange"})
+  );
+}
+
+
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {
   auto bookIds = lib.filter(kiwix::Filter().query("Wiki").creator("Wiki"));

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -473,6 +473,13 @@ TEST_F(LibraryTest, filterByCreator)
   );
 }
 
+TEST_F(LibraryTest, filterByPublisher)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwix"),
+    "An example ZIM archive",
+    "Ray Charles"
+  );
+}
 
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -496,6 +496,13 @@ TEST_F(LibraryTest, filterByCategory)
   );
 }
 
+TEST_F(LibraryTest, filterByMaxSize)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().maxSize(200000),
+    "An example ZIM archive"
+  );
+}
+
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wiki"),

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -472,18 +472,42 @@ TEST_F(LibraryTest, filterByCreator)
     "Granblue Fantasy Wiki"
   );
 
-  // filtering by creator is case sensitive
-  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("wiki"),
-    /* no results */
+  // filtering by creator is case and diacritics insensitive
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("wIkï"),
+    "Granblue Fantasy Wiki"
   );
 
-  // filtering by creator requires full match of the full author/creator name
+  // filtering by creator doesn't requires full match of the full creator name
   EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Stack"),
-    /* no results */
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
+
+  // filtering by creator requires a full phrase match (ignoring some non-word terms)
   EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Movies & TV Stack Exchange"),
     "Movies & TV Stack Exchange"
   );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Movies & TV"),
+    "Movies & TV Stack Exchange"
+  );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Movies TV"),
+    "Movies & TV Stack Exchange"
+  );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("TV & Movies"),
+    /* no results */
+  );
+  EXPECT_FILTER_RESULTS(kiwix::Filter().creator("TV Movies"),
+    /* no results */
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("creator:Wikipedia"),
+    "Encyclopédie de la Tunisie",
+    "Géographie par Wikipédia",
+    "Mathématiques",
+    "Ray Charles"
+  );
+
 }
 
 TEST_F(LibraryTest, filterByPublisher)

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -190,6 +190,9 @@ namespace
 
 class LibraryTest : public ::testing::Test {
  protected:
+  typedef kiwix::Library::BookIdCollection BookIdCollection;
+  typedef std::vector<std::string> TitleCollection;
+
   void SetUp() override {
      kiwix::Manager manager(&lib);
      manager.readOpds(sampleOpdsStream, "foo.urlHost");
@@ -200,6 +203,15 @@ class LibraryTest : public ::testing::Test {
         bookmark.setBookId(id);
         return bookmark;
     };
+
+  TitleCollection ids2Titles(const BookIdCollection& ids) {
+    TitleCollection titles;
+    for ( const auto& bookId : ids ) {
+      titles.push_back(lib.getBookById(bookId).getTitle());
+    }
+    std::sort(titles.begin(), titles.end());
+    return titles;
+  }
 
   kiwix::Library lib;
 };
@@ -246,28 +258,74 @@ TEST_F(LibraryTest, filterCheck)
   EXPECT_EQ(bookIds, lib.getBooksIds());
 
   bookIds = lib.filter(kiwix::Filter().lang("eng"));
-  EXPECT_EQ(bookIds.size(), 5U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Granblue Fantasy Wiki",
+              "Islam Stack Exchange",
+              "Movies & TV Stack Exchange",
+              "Mythology & Folklore Stack Exchange",
+              "TED talks - Business"
+            })
+  );
 
   bookIds = lib.filter(kiwix::Filter().acceptTags({"stackexchange"}));
-  EXPECT_EQ(bookIds.size(), 3U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Islam Stack Exchange",
+              "Movies & TV Stack Exchange",
+              "Mythology & Folklore Stack Exchange"
+            })
+  );
 
   bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia"}));
-  EXPECT_EQ(bookIds.size(), 3U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Encyclopédie de la Tunisie",
+              "Géographie par Wikipédia",
+              "Mathématiques"
+            })
+  );
 
   bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia", "nopic"}));
-  EXPECT_EQ(bookIds.size(), 2U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Géographie par Wikipédia",
+              "Mathématiques"
+            })
+  );
 
   bookIds = lib.filter(kiwix::Filter().acceptTags({"wikipedia"}).rejectTags({"nopic"}));
-  EXPECT_EQ(bookIds.size(), 1U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Encyclopédie de la Tunisie"
+            })
+  );
 
   bookIds = lib.filter(kiwix::Filter().query("folklore"));
-  EXPECT_EQ(bookIds.size(), 1U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Mythology & Folklore Stack Exchange"
+            })
+  );
+
 
   bookIds = lib.filter(kiwix::Filter().query("Wiki"));
-  EXPECT_EQ(bookIds.size(), 4U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Encyclopédie de la Tunisie",
+              "Granblue Fantasy Wiki",
+              "Géographie par Wikipédia",
+              "Wikiquote"
+            })
+  );
+
 
   bookIds = lib.filter(kiwix::Filter().query("Wiki").creator("Wiki"));
-  EXPECT_EQ(bookIds.size(), 1U);
+  EXPECT_EQ(ids2Titles(bookIds),
+            TitleCollection({
+              "Granblue Fantasy Wiki"
+            })
+  );
 
 }
 

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -486,6 +486,14 @@ TEST_F(LibraryTest, filterByName)
   EXPECT_FILTER_RESULTS(kiwix::Filter().name("wikibooks_de"),
     "An example ZIM archive"
   );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("name:wikibooks_de"),
+    "An example ZIM archive"
+  );
+
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query("wikibooks_de"),
+    /* no results */
+  );
 }
 
 TEST_F(LibraryTest, filterByCategory)

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -488,6 +488,14 @@ TEST_F(LibraryTest, filterByName)
   );
 }
 
+TEST_F(LibraryTest, filterByCategory)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().category("category_element_overrides_tags"),
+    "Géographie par Wikipédia",
+    "Mathématiques"
+  );
+}
+
 TEST_F(LibraryTest, filterByMultipleCriteria)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wiki"),

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -376,9 +376,11 @@ TEST_F(LibraryTest, filterByTags)
     "Mythology & Folklore Stack Exchange"
   );
 
-  // filtering by tags is case sensitive
-  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"stackEXChange"}),
-    /* no results */
+  // filtering by tags is case and diacritics insensitive
+  EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"ståckEXÇhange"}),
+    "Islam Stack Exchange",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange"
   );
 
   // filtering by tags requires full match of the search term


### PR DESCRIPTION
Fixes #484 with the exception of the `local`, `remote`, `valid` and `maxSize` filtering criteria. Those can be processed via Xapian too, but is it worth the effort (though we will gain some uniformity in how a query is fulfilled - no postprocessing through `Filter::accept()` will be needed)? 

Also
- adds diacritics insensitivity to catalog filtering by title/description
- the unit-test of `Library::filter()` is greatly enhanced