### PR TITLE
get_url() was renamed in zim::search_iterator

### DIFF
--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -241,7 +241,7 @@ _Result::_Result(zim::Search::iterator& iterator)
 
 std::string _Result::get_url()
 {
-  return iterator.get_url();
+  return iterator.get_path();
 }
 std::string _Result::get_title()
 {


### PR DESCRIPTION
Fixes #493