### PR TITLE
fixed suggestion system

### DIFF
--- a/static/skin/taskbar.js
+++ b/static/skin/taskbar.js
@@ -3,83 +3,86 @@ function htmlDecode(input) {
     return doc.documentElement.textContent;
 }
 
-(function ($) {
-    const root = $( `link[type='root']` ).attr("href");
-    const bookName = window.location.pathname.split(`${root}/`)[1].split('/')[0];
-
-    $( "#kiwixsearchbox" ).autocomplete({
-
-        source: `${root}/suggest?content=${bookName}`,
-        dataType: "json",
-        cache: false,
-
-        response: function( event, ui ) {
-              for(const item of ui.content) {
-                  item.label = htmlDecode(item.label);
-                  item.value = htmlDecode(item.value);
-                  if (item.path) item.path = htmlDecode(item.path);
-              }
-        },
-
-        select: function(event, ui) {
-            if (ui.item.kind === 'path') {
-                window.location.href = `${root}/${bookName}/${encodeURI(ui.item.path)}`;
-            } else {
-                $( "#kiwixsearchbox" ).val(ui.item.value);
-                $( "#kiwixsearchform" ).submit();
-            }
-        },
-    });
-
-    /* cybook hack */
-    if (navigator.userAgent.indexOf("bookeen/cybook") != -1) {
-        $("html").addClass("cybook");
-    }
-
-    if ($(window).width() < 520) {
-        var didScroll;
-        var lastScrollTop = 0;
-        var delta = 5;
-        // on scroll, let the interval function know the user has scrolled
-        $(window).scroll(function (event) {
-            didScroll = true;
+const jq = jQuery.noConflict(true);
+jq(document).ready(() => {
+    (function ($) {
+        const root = $( `link[type='root']` ).attr("href");
+        const bookName = window.location.pathname.split(`${root}/`)[1].split('/')[0];
+    
+        $( "#kiwixsearchbox" ).autocomplete({
+    
+            source: `${root}/suggest?content=${bookName}`,
+            dataType: "json",
+            cache: false,
+    
+            response: function( event, ui ) {
+                  for(const item of ui.content) {
+                      item.label = htmlDecode(item.label);
+                      item.value = htmlDecode(item.value);
+                      if (item.path) item.path = htmlDecode(item.path);
+                  }
+            },
+    
+            select: function(event, ui) {
+                if (ui.item.kind === 'path') {
+                    window.location.href = `${root}/${bookName}/${encodeURI(ui.item.path)}`;
+                } else {
+                    $( "#kiwixsearchbox" ).val(ui.item.value);
+                    $( "#kiwixsearchform" ).submit();
+                }
+            },
         });
-        // run hasScrolled() and reset didScroll status
-        setInterval(function () {
-            if (didScroll) {
-                hasScrolled();
-                didScroll = false;
-            }
-        }, 250);
-        function hasScrolled() {
-            var st = $(this).scrollTop();
-
-            // Make sure they scroll more than delta
-            if (Math.abs(lastScrollTop - st) <= delta)
-                return;
-
-            // If they scrolled down and are past the navbar, add class .nav-up.
-            // This is necessary so you never see what is "behind" the navbar.
-            if (st > lastScrollTop) {
-                // Scroll Down
-                $('#kiwixtoolbar').css({ top: '-100%' });
-            } else {
-                // Scroll Up
-                $('#kiwixtoolbar').css({ top: '0' });
-            }
-
-            lastScrollTop = st;
+    
+        /* cybook hack */
+        if (navigator.userAgent.indexOf("bookeen/cybook") != -1) {
+            $("html").addClass("cybook");
         }
-    }
-
-    $('#kiwixsearchbox').on({
-        focus: function () {
-            $('.kiwix_searchform').addClass('full_width');
-            $('label[for="kiwix_button_show_toggle"], .kiwix_button_cont').addClass('searching');
-        },
-        blur: function () {
-            $('.kiwix_searchform').removeClass('full_width');
-            $('label[for="kiwix_button_show_toggle"], .kiwix_button_cont').removeClass('searching');
+    
+        if ($(window).width() < 520) {
+            var didScroll;
+            var lastScrollTop = 0;
+            var delta = 5;
+            // on scroll, let the interval function know the user has scrolled
+            $(window).scroll(function (event) {
+                didScroll = true;
+            });
+            // run hasScrolled() and reset didScroll status
+            setInterval(function () {
+                if (didScroll) {
+                    hasScrolled();
+                    didScroll = false;
+                }
+            }, 250);
+            function hasScrolled() {
+                var st = $(this).scrollTop();
+    
+                // Make sure they scroll more than delta
+                if (Math.abs(lastScrollTop - st) <= delta)
+                    return;
+    
+                // If they scrolled down and are past the navbar, add class .nav-up.
+                // This is necessary so you never see what is "behind" the navbar.
+                if (st > lastScrollTop) {
+                    // Scroll Down
+                    $('#kiwixtoolbar').css({ top: '-100%' });
+                } else {
+                    // Scroll Up
+                    $('#kiwixtoolbar').css({ top: '0' });
+                }
+    
+                lastScrollTop = st;
+            }
         }
-    });
-})(jQuery);
+    
+        $('#kiwixsearchbox').on({
+            focus: function () {
+                $('.kiwix_searchform').addClass('full_width');
+                $('label[for="kiwix_button_show_toggle"], .kiwix_button_cont').addClass('searching');
+            },
+            blur: function () {
+                $('.kiwix_searchform').removeClass('full_width');
+                $('label[for="kiwix_button_show_toggle"], .kiwix_button_cont').removeClass('searching');
+            }
+        });
+    })(jq);
+})

--- a/static/templates/head_taskbar.html
+++ b/static/templates/head_taskbar.html
@@ -1,6 +1,6 @@
 <link type="text/css" href="{{root}}/skin/jquery-ui/jquery-ui.min.css" rel="Stylesheet" />
 <link type="text/css" href="{{root}}/skin/jquery-ui/jquery-ui.theme.min.css" rel="Stylesheet" />
 <link type="text/css" href="{{root}}/skin/taskbar.css" rel="Stylesheet" />
-<script type="text/javascript" src="{{root}}/skin/jquery-ui/external/jquery/jquery.js"></script>
-<script type="text/javascript" src="{{root}}/skin/jquery-ui/jquery-ui.min.js"></script>
-<script type="text/javascript" src="{{root}}/skin/taskbar.js" async></script>
+<script type="text/javascript" src="{{root}}/skin/jquery-ui/external/jquery/jquery.js" defer></script>
+<script type="text/javascript" src="{{root}}/skin/jquery-ui/jquery-ui.min.js" defer></script>
+<script type="text/javascript" src="{{root}}/skin/taskbar.js" defer></script>


### PR DESCRIPTION
@mgautierfr @kelson42 this resolves kiwix/kiwix-tools#446
and this moves #483 to a branch in kiwix/kiwiwx-lib

problem - suggestion system worked sometimes and failed otherwise as there was an async attribute added to `taskbar.js` script tag which made it load and executed earlier than jquery modules causing it to pick jquery which was available without following the order of loading modules.

fix - I have removed that async attribute and added defer to the scripts we load so that we can be sure of the order of loading of scripts, I have also kept `jQuery.noConflict` as the jquery we load should not conflict with jquery added by the zimfile.
also, the whole `taskbar.js` is still under a `jq(document).ready()` as all jquery operations should always occur after all elements required by jQuery are completely loaded.
