### PR TITLE
Empty query acts as a match-all query

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -327,7 +327,7 @@ bool willSelectEverything(const Xapian::Query& query)
 
 Xapian::Query buildXapianQueryFromFilterQuery(const Filter& filter)
 {
-  if ( !filter.hasQuery() ) {
+  if ( !filter.hasQuery() || filter.getQuery().empty() ) {
     // This is a thread-safe way to construct an equivalent of
     // a Xapian::Query::MatchAll query
     return Xapian::Query(std::string());

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -479,6 +479,24 @@ TEST_F(LibraryTest, filterByQuery)
 }
 
 
+TEST_F(LibraryTest, filteringByEmptyQueryReturnsAllEntries)
+{
+  EXPECT_FILTER_RESULTS(kiwix::Filter().query(""),
+    "An example ZIM archive",
+    "Encyclopédie de la Tunisie",
+    "Granblue Fantasy Wiki",
+    "Géographie par Wikipédia",
+    "Islam Stack Exchange",
+    "Mathématiques",
+    "Movies & TV Stack Exchange",
+    "Mythology & Folklore Stack Exchange",
+    "Ray Charles",
+    "TED talks - Business",
+    "Tania Louis",
+    "Wikiquote"
+  );
+}
+
 TEST_F(LibraryTest, filterByCreator)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Wikipedia"),


### PR DESCRIPTION
Should fix #500

After switching to Xapian-based search in the library/catalog, an empty query stopped acting as a match-all query. This commit restores the old behaviour in that regard.