### PR TITLE
Revert "added 204 code for empty return of search"

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -555,11 +555,6 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
     renderer.setPageLength(pageLength);
     auto response = ContentResponse::build(*this, renderer.getHtml(), "text/html; charset=utf-8");
     response->set_taskbar(bookName, reader ? reader->getTitle() : "");
-    //changing status code if no result obtained
-    if(searcher.getEstimatedResultCount() == 0)
-    {
-      response->set_code(MHD_HTTP_NO_CONTENT);
-    }
 
     return std::move(response);
   } catch (const std::exception& e) {
@@ -765,7 +760,7 @@ std::unique_ptr<Response> InternalServer::handle_content(const RequestContext& r
     std::string searchURL = m_root+"/search?pattern="+pattern; // Make a full search on the entire library.
     const std::string details = searchSuggestionHTML(searchURL, kiwix::urlDecode(pattern));
 
-    return Response::build_404(*this, request, bookName, details); 
+    return Response::build_404(*this, request, bookName, details);
   }
 
   auto urlStr = request.get_url().substr(bookName.size()+1);

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -216,15 +216,6 @@ TEST_F(ServerTest, 200)
     EXPECT_EQ(200, zfs1_->GET(res.url)->status) << "res.url: " << res.url;
 }
 
-// seperate test for 204 code
-
-TEST_F(ServerTest, EmptySearchReturnsA204StatusCode)
-{
-  const char* url="/search?content=zimfile&pattern=abcd";
-  auto res=zfs1_->GET(url);
-  EXPECT_EQ(204, res->status) << "res.url: " << url;
-}
-
 TEST_F(ServerTest, CompressibleContentIsCompressedIfAcceptable)
 {
   for ( const Resource& res : resources200Compressible ) {


### PR DESCRIPTION
Fixes #466 

Returning status code `204` in case of empty results doesn't show the empty results page as described in #466. Reverting the changes in #396 fixes the issue. We should be returning status code `200` and the client should be able to figure out the "empty result" from the response itself.

Changes included in this PR:
- Removes the use of `204` status code in case of empty results in the internal server.
- Removes the corresponding server test.